### PR TITLE
Enable Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
 
 env:
   global:
-    - secure: lEDam2X+/RJfqstC/MhByuqvH0vaT8FRLRY3Uq0stmCeTLJssSicu9MTj3BffoR3TFaadsgEDZs0KpAdj6WSqI64c+DxnhGreOe19iSPaQt54rizJAxz//Pav2nW3weP5zbXWB+Pbm9cCJdB7NNvmaH+KRmfYAJj/pwzSOIQO3SvgCulU36Dpw6oC6PkCa6gWPHkH9FTivxaoltx2DYav4dM3JLAKa1JhssbcOp6Hk/pnlNLsDNKY2bWlzfzPXHeue78V/d/63hhjcS0g0f18X/RXwUVuaL/TcJSmpTTvk8jy0sgvl9dP7mdV4eA2DdOPVp9IeSj0I0eELATHC9lUg7Msupq7kveZtqX4vOqlmiP88JvUQhkJT+/kQCIwYCk+v3PzKMnj6iJck567ckGRSauyEHVSyPVW4F6XSw1h9V/Awme1fdJAiyANWhpyVqUIvdZANKSRJwPwobb28HShl6yyFAT+D2mb8ayM5LBMPG4xlYI14+Ww4JKPa9OFU12W65gN7gO8VIUiQyMND2P62yglIJWk5w5cEIA3hHXT+rBOHpuS88vozE4j54lLYQGHSqMEZsCmbFWNxhLfdhEvKNyG7UiS1udD1hWkwvZ0U6fLZ2XFWbxhENFdZ9em6pI/Jq2KhkAxAgjYAuQUk2zgI7hpEQ/MBKO296hTJjCg9Q=
     - REPO_VERSION="$(npx -c 'echo "$npm_package_version"')"
 
 before_install:
@@ -28,7 +27,6 @@ deploy:
     on:
       branch: master
   - provider: npm
-    email: "npmjs@marcosvrs.com"
     api_key: $NPM_API_KEY
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: node_js
+
+node_js:
+  - "node"
+  - "lts/*"
+
+env:
+  global:
+    - secure: lEDam2X+/RJfqstC/MhByuqvH0vaT8FRLRY3Uq0stmCeTLJssSicu9MTj3BffoR3TFaadsgEDZs0KpAdj6WSqI64c+DxnhGreOe19iSPaQt54rizJAxz//Pav2nW3weP5zbXWB+Pbm9cCJdB7NNvmaH+KRmfYAJj/pwzSOIQO3SvgCulU36Dpw6oC6PkCa6gWPHkH9FTivxaoltx2DYav4dM3JLAKa1JhssbcOp6Hk/pnlNLsDNKY2bWlzfzPXHeue78V/d/63hhjcS0g0f18X/RXwUVuaL/TcJSmpTTvk8jy0sgvl9dP7mdV4eA2DdOPVp9IeSj0I0eELATHC9lUg7Msupq7kveZtqX4vOqlmiP88JvUQhkJT+/kQCIwYCk+v3PzKMnj6iJck567ckGRSauyEHVSyPVW4F6XSw1h9V/Awme1fdJAiyANWhpyVqUIvdZANKSRJwPwobb28HShl6yyFAT+D2mb8ayM5LBMPG4xlYI14+Ww4JKPa9OFU12W65gN7gO8VIUiQyMND2P62yglIJWk5w5cEIA3hHXT+rBOHpuS88vozE4j54lLYQGHSqMEZsCmbFWNxhLfdhEvKNyG7UiS1udD1hWkwvZ0U6fLZ2XFWbxhENFdZ9em6pI/Jq2KhkAxAgjYAuQUk2zgI7hpEQ/MBKO296hTJjCg9Q=
+    - REPO_VERSION="$(npx -c 'echo "$npm_package_version"')"
+
+before_install:
+  - echo "REPO_VERSION=$REPO_VERSION"
+
+before_script:
+  - npm run lint
+
+before_deploy:
+  - |
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
+      git tag -a -f "$REPO_VERSION"
+      echo "New Tag $(git describe --tags)";
+    fi
+
+deploy:
+  - provider: releases
+    api_key: $GITHUB_TOKEN
+    on:
+      branch: master
+  - provider: npm
+    email: "npmjs@marcosvrs.com"
+    api_key: $NPM_API_KEY
+    on:
+      tags: true


### PR DESCRIPTION
### **Please, do not merge before enabling Travis!**

* Enable npm publish via travis;
* For all commits:
   * run `npm run lint`;
   * run `npm test`;
* For all commits on master:
   * create a new tag with the package version and a new github release;
* For all tags:
    * Publish the new version to npm;

*Note*
@bafolts The best would be to generate a new npm api key just for it, I prefer to not use my own account for it. Also, for the github key.