### PR TITLE
Support multi-inheritance of interfaces

### DIFF
--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -32,7 +32,7 @@ export namespace ClassFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        result.extendsClass = ComponentFactory.getExtendsHeritageClauseName(heritageClause);
+                        result.extendsClass = ComponentFactory.getExtendsHeritageClauseNames(heritageClause)[0];
                     } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
                         result.implementsInterfaces = ComponentFactory.getImplementsHeritageClauseNames(heritageClause);
                     }

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -89,8 +89,8 @@ export namespace ComponentFactory {
         return 'public';
     }
 
-    export function getExtendsHeritageClauseName(heritageClause: ts.HeritageClause): string {
-        return (<ts.Identifier>heritageClause.types[0].expression).text;
+    export function getExtendsHeritageClauseNames(heritageClause: ts.HeritageClause): string[] {
+        return heritageClause.types.map(getInterfaceName);
     }
 
     function getInterfaceName(nodeObject: ts.ExpressionWithTypeArguments): string {

--- a/src/Factories/InterfaceFactory.ts
+++ b/src/Factories/InterfaceFactory.ts
@@ -18,7 +18,7 @@ export namespace InterfaceFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        result.extendsInterface = [ComponentFactory.getExtendsHeritageClauseName(heritageClause)];
+                        result.extendsInterface = ComponentFactory.getExtendsHeritageClauseNames(heritageClause);
                     }
                 });
             }

--- a/test/Handbook/Interfaces/ExtendingInterfaces.ts
+++ b/test/Handbook/Interfaces/ExtendingInterfaces.ts
@@ -1,0 +1,11 @@
+interface Shape {
+  color: string;
+}
+
+interface PenStroke {
+  penWidth: number;
+}
+
+interface Square extends Shape, PenStroke {
+  sideLength: number;
+}

--- a/test/handbook.test.ts
+++ b/test/handbook.test.ts
@@ -150,4 +150,19 @@ describe('Parse Handbook codes', () => {
                 '}',
                 '@enduml'].join(os.EOL));
     });
+
+    it('generate PlantUML for Interfaces/ExtendingInterfaces.ts', () => {
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Handbook/Interfaces/ExtendingInterfaces.ts'])))
+            .toEqual(`@startuml
+interface Shape {
+    +color: string
+}
+interface PenStroke {
+    +penWidth: number
+}
+interface Square extends Shape, PenStroke {
+    +sideLength: number
+}
+@enduml`);
+    });
 });


### PR DESCRIPTION
Typescript allows an interface to extend multiple other instances. Currently tplant doesn't support this case.

As an example, given:
```
interface Shape {
  color: string;
}

interface PenStroke {
  penWidth: number;
}

interface Square extends Shape, PenStroke {
  sideLength: number;
}
```
tplant currently generates the following which is incorrect:
```
@startuml
interface Shape {
    +color: string
}
interface PenStroke {
    +penWidth: number
}
interface Square extends Shape {  // should extend both Shape and PenStroke
    +sideLength: number
}
@enduml
```

This change produces correct PUML for such cases.