### PR TITLE
Target class

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,14 @@ Car --> "*" Wheel
 ### -I, --only-interfaces
     Only convert interfaces
 
+### -f, --format mermaid
+
+By default it is `plantuml`
+If `mermaid` is specific, then the class diagram is generated for [mermaidjs](https://mermaid-js.github.io/mermaid/#/classDiagram)
+
+### --targetClass MyClass
+
+If specified will generated the hierarchy class diagram of the specified class
+
 # References
 https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API

--- a/src/Formatter/MermaidFormat.ts
+++ b/src/Formatter/MermaidFormat.ts
@@ -24,6 +24,9 @@ export class MermaidFormat extends Formatter {
         const result: string[] = [];
         const firstLine: string[] = [];
         firstLine.push(`class ${comp.name}`);
+        if (comp.name === this.options.targetClass) {
+            firstLine.push(':::targetClassDiagram');
+        }
         if (comp.typeParameters.length > 0) {
             firstLine.push('~');
             firstLine.push(comp.typeParameters

--- a/src/Models/Formatter.ts
+++ b/src/Models/Formatter.ts
@@ -10,6 +10,7 @@ import { Parameter } from '../Components/Parameter';
 import { Property } from '../Components/Property';
 import { TypeParameter } from '../Components/TypeParameter';
 import { ComponentKind } from './ComponentKind';
+import { ICommandOptions } from './ICommandOptions';
 import { IComponentComposite } from './IComponentComposite';
 
 const REGEX_ONLY_TYPE_NAMES: RegExp = /\w+/g;
@@ -19,6 +20,15 @@ const REGEX_TYPE_NAMES_WITH_ARRAY: RegExp = /\w+(?:\[\])?/g;
  * Define a format for class diagram
  */
 export abstract class Formatter {
+
+    /**
+     * Options sent to the cli
+     */
+    protected options: ICommandOptions;
+
+    constructor(options: ICommandOptions) {
+        this.options = options;
+    }
 
     public header() : string[] {
         return [];

--- a/src/Models/ICommandOptions.ts
+++ b/src/Models/ICommandOptions.ts
@@ -1,4 +1,5 @@
 export interface ICommandOptions {
+    targetClass?: string;
     associations: boolean;
     onlyInterfaces: boolean;
     format?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ commander
     .option('-A, --associations', 'Show associations between classes with cardinalities')
     .option('-I, --only-interfaces', 'Only output interfaces')
     .option('-f, --format <path>', 'Define the format of output')
+    .option('-T, --targetClass <className>', 'Display class hierarchy diagram')
     .parse(process.argv);
 
 if (!commander.input) {
@@ -46,7 +47,8 @@ G(<string>commander.input, {}, (err: Error | null, matches: string[]): void => {
         {
             associations: <boolean>commander.associations,
             onlyInterfaces: <boolean>commander.onlyInterfaces,
-            format: <string> commander.format
+            format: <string> commander.format,
+            targetClass: <string> commander.targetClass
         }
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { tplant } from './tplant';
 const AVAILABLE_PLANTUML_EXTENSIONS: string[] = ['svg', 'png', 'txt'];
 
 commander
-    .version('2.4.0')
+    .version(require('../package').version) // tslint:disable-line
     .option('-i, --input <path>', 'Define the path of the Typescript file')
     .option('-o, --output <path>', 'Define the path of the output file. If not defined, it\'ll output on the STDOUT')
     .option(

--- a/src/tplant.ts
+++ b/src/tplant.ts
@@ -5,6 +5,7 @@ import { ComponentKind } from './Models/ComponentKind';
 import { Formatter } from './Models/Formatter';
 import { IComponentComposite } from './Models/IComponentComposite';
 
+import { Class } from './Components/Class';
 import { FileFactory } from './Factories/FileFactory';
 import { MermaidFormat } from './Formatter/MermaidFormat';
 import { ICommandOptions } from './Models/ICommandOptions';
@@ -44,20 +45,84 @@ export namespace tplant {
         format: 'plantuml'
     }): string {
 
+        let formatter : Formatter;
+        if (options.format === 'mermaid') {
+            formatter = new MermaidFormat(options);
+        } else {
+            formatter = new PlantUMLFormat(options);
+        }
+
+        // Only display interfaces
         if (options.onlyInterfaces) {
             for (const file of files) {
                 (<File>file).parts = (<File>file).parts
                     .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.INTERFACE);
             }
-        }
+        } else if (options.targetClass !== undefined) {
+            // Find the class to display
+            const target : Class = <Class> findClass(files, options.targetClass);
+            const parts : IComponentComposite[] = [];
+            if (target !== undefined) {
+                parts.push(target);
+                // Add all the ancestor for the class recursively
+                let parent : string | undefined = target.extendsClass;
+                // Add the parent
+                while (parent !== undefined) {
+                    const parentClass : Class = <Class> findClass(files, parent);
+                    parts.push(parentClass);
+                    parts.push(...getInterfaces(files, parentClass));
+                    parent = parentClass.extendsClass;
+                }
+                // Add all the interface
+                parts.push(...getInterfaces(files, target));
+                // Add all child class recursively
+                parts.push(...findChildClass(files, target));
+            }
 
-        let formatter : Formatter;
-        if (options.format === 'mermaid') {
-            formatter = new MermaidFormat();
-        } else {
-            formatter = new PlantUMLFormat();
+            return formatter.renderFiles(parts, false);
         }
 
         return formatter.renderFiles(files, options.associations);
+    }
+
+    function getInterfaces(files:  IComponentComposite[], comp: Class) : IComponentComposite[] {
+        const res: IComponentComposite[] = [];
+        comp.implementsInterfaces.forEach((impl: string) => {
+            const implComponent : IComponentComposite | undefined = findClass(files, impl);
+            if (implComponent !== undefined) {
+                res.push(implComponent);
+            }
+        });
+
+        return res;
+    }
+
+    function findClass(files: IComponentComposite[], name: string) : IComponentComposite | undefined {
+        for (const file of files) {
+            for (const part of (<File>file).parts) {
+                if (part.name === name) {
+                    return part;
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    function findChildClass(files: IComponentComposite[], comp: IComponentComposite) : IComponentComposite[] {
+        const res: IComponentComposite[] = [];
+        for (const file of files) {
+            (<File>file).parts
+                .forEach((part: IComponentComposite): void => {
+                    if (part instanceof Class && (part).extendsClass === comp.name) {
+                        res.push(part);
+                        // Reset interface
+                        part.implementsInterfaces = [];
+                        res.push(...findChildClass(files, part));
+                    }
+                });
+        }
+
+        return res;
     }
 }

--- a/test/mermaid/playground.test.ts
+++ b/test/mermaid/playground.test.ts
@@ -50,6 +50,16 @@ describe('Parse Playground codes (with Mermaid)', () => {
             .toEqual(loadResult("autos"));
     });
 
+    it('generate MermaidJS for Inheritance/autos.ts targeting Vehicle', () => {
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {format: "mermaid", associations: false, onlyInterfaces: false, targetClass: "Vehicle"}))
+            .toEqual(loadResult("autos_vehicle"));
+    });
+
+    it('generate MermaidJS for Inheritance/autos.ts targeting Car', () => {
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {format: "mermaid", associations: false, onlyInterfaces: false, targetClass: "Car"}))
+            .toEqual(loadResult("autos_car"));
+    });
+
     it('generate MermaidJS for RayTracer', () => {
         expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), {format: "mermaid", associations: true, onlyInterfaces: false}))
             .toEqual(loadResult("raytracer"));

--- a/test/mermaid/results/playground_autos_car
+++ b/test/mermaid/results/playground_autos_car
@@ -1,0 +1,20 @@
+classDiagram
+Vehicle <|-- Car
+class Car:::targetClassDiagram {
+    +start(): string
+}
+IVehicle <|.. Vehicle
+class Vehicle {
+    +color: string
+    +start(type: string): string
+}
+class IVehicle {
+    +start(type: string): string
+}
+<<Interface>> IVehicle
+Car <|-- Sedan
+class Sedan {
+    +start(): string
+    +openTrunk(): void
+    +openWindow(): void
+}

--- a/test/mermaid/results/playground_autos_vehicle
+++ b/test/mermaid/results/playground_autos_vehicle
@@ -1,0 +1,24 @@
+classDiagram
+IVehicle <|.. Vehicle
+class Vehicle:::targetClassDiagram {
+    +color: string
+    +start(type: string): string
+}
+class IVehicle {
+    +start(type: string): string
+}
+<<Interface>> IVehicle
+Vehicle <|-- Car
+class Car {
+    +start(): string
+}
+Car <|-- Sedan
+class Sedan {
+    +start(): string
+    +openTrunk(): void
+    +openWindow(): void
+}
+Vehicle <|-- Truck
+class Truck {
+    +start(): string
+}


### PR DESCRIPTION
Added a --targetClass to select only the class hierarchy 

For example, a full diagram like

```
classDiagram
IVehicle <|.. Vehicle
class Vehicle {
    +color: string
    +start(type: string): string
}
class IVehicle {
    +start(type: string): string
}
<<Interface>> IVehicle
Vehicle <|-- Car
class Car {
    +start(): string
}
class ITrunk {
    +openTrunk(): void
}
<<Interface>> ITrunk
class IWindow {
    +openWindow(): void
}
<<Interface>> IWindow
Car <|-- Sedan
ITrunk <|.. Sedan
IWindow <|.. Sedan
class Sedan {
    +start(): string
    +openTrunk(): void
    +openWindow(): void
}
Vehicle <|-- Truck
class Truck {
    +start(): string
}
```

If launched with `--targetClass Vehicle` the result will be stripped to

```
classDiagram
IVehicle <|.. Vehicle
class Vehicle:::targetClassDiagram {
    +color: string
    +start(type: string): string
}
class IVehicle {
    +start(type: string): string
}
<<Interface>> IVehicle
Vehicle <|-- Car
class Car {
    +start(): string
}
Car <|-- Sedan
class Sedan {
    +start(): string
    +openTrunk(): void
    +openWindow(): void
}
Vehicle <|-- Truck
class Truck {
    +start(): string
}
```