### PR TITLE
feat: allow output only classes (Close #64)

### DIFF
--- a/src/Formatter/MermaidFormat.ts
+++ b/src/Formatter/MermaidFormat.ts
@@ -38,7 +38,7 @@ export class MermaidFormat extends Formatter {
         if (comp.extendsClass !== undefined) {
             result.push(`${comp.extendsClass} <|-- ${comp.name}`);
         }
-        if (comp.implementsInterfaces.length > 0) {
+        if (!this.options.onlyClasses && comp.implementsInterfaces.length > 0) {
             comp.implementsInterfaces.map((inter: string) => {
                 result.push(`${inter} <|.. ${comp.name}`);
             });

--- a/src/Formatter/PlantUMLFormat.ts
+++ b/src/Formatter/PlantUMLFormat.ts
@@ -47,7 +47,7 @@ export class PlantUMLFormat extends Formatter {
         if (comp.extendsClass !== undefined) {
             firstLine.push(` extends ${comp.extendsClass}`);
         }
-        if (comp.implementsInterfaces.length > 0) {
+        if (!this.options.onlyClasses && comp.implementsInterfaces.length > 0) {
             firstLine.push(` implements ${comp.implementsInterfaces.join(', ')}`);
         }
         this.serializeMembers(comp, firstLine, result);

--- a/src/Models/ICommandOptions.ts
+++ b/src/Models/ICommandOptions.ts
@@ -3,4 +3,5 @@ export interface ICommandOptions {
     associations: boolean;
     onlyInterfaces: boolean;
     format?: string;
+    onlyClasses: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ commander
     )
     .option('-A, --associations', 'Show associations between classes with cardinalities')
     .option('-I, --only-interfaces', 'Only output interfaces')
+    .option('-C, --only-classes', 'Only output classes')
     .option('-f, --format <path>', 'Define the format of output')
     .option('-T, --targetClass <className>', 'Display class hierarchy diagram')
     .parse(process.argv);
@@ -48,7 +49,8 @@ G(<string>commander.input, {}, (err: Error | null, matches: string[]): void => {
             associations: <boolean>commander.associations,
             onlyInterfaces: <boolean>commander.onlyInterfaces,
             format: <string> commander.format,
-            targetClass: <string> commander.targetClass
+            targetClass: <string> commander.targetClass,
+            onlyClasses: <boolean> commander.onlyClasses
         }
     );
 

--- a/src/tplant.ts
+++ b/src/tplant.ts
@@ -42,7 +42,8 @@ export namespace tplant {
     export function convertToPlant(files: IComponentComposite[], options: ICommandOptions = {
         associations: false,
         onlyInterfaces: false,
-        format: 'plantuml'
+        format: 'plantuml',
+        onlyClasses: false
     }): string {
 
         let formatter : Formatter;
@@ -53,7 +54,12 @@ export namespace tplant {
         }
 
         // Only display interfaces
-        if (options.onlyInterfaces) {
+        if (options.onlyClasses) {
+            for (const file of files) {
+                (<File>file).parts = (<File>file).parts
+                    .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.CLASS);
+            }
+        } else if (options.onlyInterfaces) {
             for (const file of files) {
                 (<File>file).parts = (<File>file).parts
                     .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.INTERFACE);

--- a/test/arguments.test.ts
+++ b/test/arguments.test.ts
@@ -4,7 +4,7 @@ import { tplant } from '../src/tplant';
 describe('Test commander options', () => {
 
     it('generate PlantUML with only Interfaces for Playground/Inheritance/autos.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), { associations: false, onlyInterfaces: true }))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), { associations: false, onlyInterfaces: true, onlyClasses: false }))
             .toEqual(
                 ['@startuml',
                     'interface IVehicle {',
@@ -20,7 +20,7 @@ describe('Test commander options', () => {
     });
 
     it('generate PlantUML for RayTracer with associations', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), { associations: true, onlyInterfaces: false }))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), { associations: true, onlyInterfaces: false, onlyClasses: false }))
             .toEqual(
                 ['@startuml',
                     'class Vector {',
@@ -142,7 +142,7 @@ describe('Test commander options', () => {
     });
 
     it('generate PlantUML for Generics/Complex.ts with associations', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Complex.ts']), { associations: true, onlyInterfaces: false }))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Complex.ts']), { associations: true, onlyInterfaces: false, onlyClasses: false }))
             .toEqual(
                 ['@startuml',
                     'interface GenericInterface<T extends string> {',
@@ -181,7 +181,7 @@ describe('Test commander options', () => {
     });
 
     it('generate PlantUML for Generics/RecursiveGenericType.ts with associations', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/RecursiveGenericType.ts']), { associations: true, onlyInterfaces: false }))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/RecursiveGenericType.ts']), { associations: true, onlyInterfaces: false, onlyClasses: false }))
             .toEqual(
                 ['@startuml',
                     'interface FirstGeneric<T> {',
@@ -211,7 +211,7 @@ describe('Test commander options', () => {
     });
 
     it('generate PlantUML for RayTracer with associations and only Interfaces', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), { associations: true, onlyInterfaces: true }))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), { associations: true, onlyInterfaces: true, onlyClasses: false }))
             .toEqual(
                 ['@startuml',
                     'interface Ray {',

--- a/test/cjk.test.ts
+++ b/test/cjk.test.ts
@@ -4,7 +4,7 @@ import { tplant } from '../src/tplant';
 describe('Parse codes that contains CJK characters', () => {
     it('generate PlantUML for classes that contains CJK characters', () => {
         expect(tplant.convertToPlant(
-                tplant.generateDocumentation(['test/CJK/CJK.ts']), { associations: false, onlyInterfaces: false })
+                tplant.generateDocumentation(['test/CJK/CJK.ts']), { associations: false, onlyInterfaces: false, onlyClasses: false })
                 .replace(/(?:\r\n)/g, '\n') // windows has \r in line endings
                 )
             .toEqual(`@startuml

--- a/test/mermaid/handbook.test.ts
+++ b/test/mermaid/handbook.test.ts
@@ -2,10 +2,12 @@ import { tplant } from '../../src/tplant';
 import { join } from "path";
 import { readFileSync } from "fs";
 
+import { mermaidArguments } from "./playground.test";
+
 describe('Parse Handbook codes (with Mermaid)', () => {
 
     it('generate MermaidJS for Basic Types/BasicTypes.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Handbook/Basic Types/BasicTypes.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Handbook/Basic Types/BasicTypes.ts']), mermaidArguments))
             .toEqual(readFileSync(join(__dirname, "results", "handbook_basictypes")).toString());
     });
 });

--- a/test/mermaid/playground.test.ts
+++ b/test/mermaid/playground.test.ts
@@ -6,62 +6,75 @@ function loadResult(name: string) {
     return readFileSync(join(__dirname, "results", `playground_${name}`)).toString();
 }
 
+export const mermaidArguments = {
+    format: "mermaid",
+    associations: false,
+    onlyInterfaces: false,
+    onlyClasses: false
+}
+
 describe('Parse Playground codes (with Mermaid)', () => {
 
     it('generate MermaidJS for Abstract/AbstractClass.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Abstract/AbstractClass.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Abstract/AbstractClass.ts']), mermaidArguments))
             .toEqual(
                 loadResult("abstract")
             );
     });
 
     it('generate MermaidJS for Classes/Greeter.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Classes/Greeter.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Classes/Greeter.ts']), mermaidArguments))
             .toEqual(loadResult("greeter"));
     });
 
     it('generate MermaidJS for Enum/Enum.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Enum/Enum.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Enum/Enum.ts']), mermaidArguments))
             .toEqual(loadResult("enum"));
     });
 
     it('generate MermaidJS for Inheritance', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/index.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/index.ts']), mermaidArguments))
             .toEqual(loadResult("inheritance"));
     });
 
     it('generate MermaidJS for Generics/Complex.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Complex.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Complex.ts']), mermaidArguments))
             .toEqual(loadResult("complex"));
     });
 
     it('generate MermaidJS for Generics/Greeter.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Greeter.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/Greeter.ts']), mermaidArguments))
             .toEqual(loadResult("generic_greeter"));
     });
 
     it('generate MermaidJS for Generics/RecursiveGenericType.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/RecursiveGenericType.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/RecursiveGenericType.ts']), mermaidArguments))
             .toEqual(loadResult("recursive_generic"));
     });
 
     it('generate MermaidJS for Inheritance/autos.ts', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {format: "mermaid", associations: false, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), mermaidArguments))
             .toEqual(loadResult("autos"));
     });
 
     it('generate MermaidJS for Inheritance/autos.ts targeting Vehicle', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {format: "mermaid", associations: false, onlyInterfaces: false, targetClass: "Vehicle"}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {...mermaidArguments, targetClass: "Vehicle"}))
             .toEqual(loadResult("autos_vehicle"));
     });
 
     it('generate MermaidJS for Inheritance/autos.ts targeting Car', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {format: "mermaid", associations: false, onlyInterfaces: false, targetClass: "Car"}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {...mermaidArguments, targetClass: "Car"}))
             .toEqual(loadResult("autos_car"));
     });
 
     it('generate MermaidJS for RayTracer', () => {
-        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), {format: "mermaid", associations: true, onlyInterfaces: false}))
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/RayTracer/index.ts']), {...mermaidArguments, associations: true}))
             .toEqual(loadResult("raytracer"));
     });
+
+    it('generate MermaidJS for Inheritance/autos.ts without interfaces', () => {
+        expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Inheritance/autos.ts']), {...mermaidArguments, onlyClasses: true}))
+            .toEqual(loadResult("autos_classonly"));
+    });
+
 });

--- a/test/mermaid/results/playground_autos_classonly
+++ b/test/mermaid/results/playground_autos_classonly
@@ -1,0 +1,19 @@
+classDiagram
+class Vehicle {
+    +color: string
+    +start(type: string): string
+}
+Vehicle <|-- Car
+class Car {
+    +start(): string
+}
+Car <|-- Sedan
+class Sedan {
+    +start(): string
+    +openTrunk(): void
+    +openWindow(): void
+}
+Vehicle <|-- Truck
+class Truck {
+    +start(): string
+}


### PR DESCRIPTION
I added a `--only-classes` parameter to filter out Interfaces and implements within classes