### PR TITLE
Fix file name in File Component

### DIFF
--- a/src/Components/File.ts
+++ b/src/Components/File.ts
@@ -1,11 +1,10 @@
 import { ComponentKind } from '../Models/ComponentKind';
-import { IComponentComposite } from '../Models/IComponentComposite';
+import { IComponentComposite, ComponentComposite } from '../Models/IComponentComposite';
 
 /**
  * Represents the metadata for a file containing typescript
  */
-export class File implements IComponentComposite {
+export class File extends ComponentComposite {
     public readonly componentKind: ComponentKind = ComponentKind.FILE;
-    public readonly name: string = '';
     public parts: IComponentComposite[] = [];
 }

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -3,8 +3,8 @@ import { File } from '../Components/File';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
-    export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
-        const file: File = new File(sourceFile.getName());
+    export function create(sourceFile: ts.SourceFile, checker: ts.TypeChecker): File {
+        const file: File = new File(sourceFile.fileName);
         file.parts = ComponentFactory.create(sourceFile, checker);
 
         return file;

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -4,7 +4,7 @@ import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
     export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
-        const file: File = new File();
+        const file: File = new File(sourceFile.name);
         file.parts = ComponentFactory.create(sourceFile, checker);
 
         return file;

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -4,7 +4,7 @@ import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
     export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
-        const file: File = new File(sourceFile.name);
+        const file: File = new File(sourceFile.getName());
         file.parts = ComponentFactory.create(sourceFile, checker);
 
         return file;


### PR DESCRIPTION
I noticed that files in the tplant.generateDocumentation() function were returning name='' (empty string); Also, I noticed that the file order was not the same as the list of files going in.

I think I got that property populated now for the documentation results.