### PR TITLE
Class filename feature

### DIFF
--- a/src/Components/Class.ts
+++ b/src/Components/Class.ts
@@ -6,6 +6,7 @@ import { ComponentComposite, IComponentComposite } from '../Models/IComponentCom
  */
 export class Class extends ComponentComposite {
     public readonly componentKind: ComponentKind = ComponentKind.CLASS;
+    public readonly fileName: string;
     public isAbstract: boolean = false;
     public isStatic: boolean = false;
     public constructorMethods: IComponentComposite[] = [];
@@ -14,4 +15,8 @@ export class Class extends ComponentComposite {
     public implementsInterfaces: string[] = [];
     public typeParameters: IComponentComposite[] = [];
 
+    constructor(name: string, fileName: string) {
+        super(name);
+        this.fileName = fileName;
+    }
 }

--- a/src/Components/Class.ts
+++ b/src/Components/Class.ts
@@ -12,7 +12,9 @@ export class Class extends ComponentComposite {
     public constructorMethods: IComponentComposite[] = [];
     public members: IComponentComposite[] = [];
     public extendsClass: string | undefined;
+    public extendsClassFile: string | undefined;
     public implementsInterfaces: string[] = [];
+    public implementsInterfacesFiles: string[] = [];
     public typeParameters: IComponentComposite[] = [];
 
     constructor(name: string, fileName: string) {

--- a/src/Components/File.ts
+++ b/src/Components/File.ts
@@ -1,11 +1,10 @@
 import { ComponentKind } from '../Models/ComponentKind';
-import { IComponentComposite } from '../Models/IComponentComposite';
+import { ComponentComposite, IComponentComposite } from '../Models/IComponentComposite';
 
 /**
  * Represents the metadata for a file containing typescript
  */
-export class File implements IComponentComposite {
+export class File extends ComponentComposite {
     public readonly componentKind: ComponentKind = ComponentKind.FILE;
-    public readonly name: string = '';
     public parts: IComponentComposite[] = [];
 }

--- a/src/Components/File.ts
+++ b/src/Components/File.ts
@@ -1,10 +1,11 @@
 import { ComponentKind } from '../Models/ComponentKind';
-import { ComponentComposite, IComponentComposite } from '../Models/IComponentComposite';
+import { IComponentComposite } from '../Models/IComponentComposite';
 
 /**
  * Represents the metadata for a file containing typescript
  */
-export class File extends ComponentComposite {
+export class File implements IComponentComposite {
     public readonly componentKind: ComponentKind = ComponentKind.FILE;
+    public readonly name: string = '';
     public parts: IComponentComposite[] = [];
 }

--- a/src/Components/Interface.ts
+++ b/src/Components/Interface.ts
@@ -8,5 +8,6 @@ export class Interface extends ComponentComposite {
     public readonly componentKind: ComponentKind = ComponentKind.INTERFACE;
     public members: IComponentComposite[] = [];
     public extendsInterface: string[] = [];
+    public extendsInterfaceFiles: string[] = [];
     public typeParameters: IComponentComposite[] = [];
 }

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -32,11 +32,11 @@ export namespace ClassFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        let extendsClass = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
+                        const extendsClass = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
                         result.extendsClass = extendsClass[0];
                         result.extendsClassFile = extendsClass[1];
                     } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
-                        let implementsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        const implementsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
                         result.implementsInterfaces = implementsInterfaces.map(arr => arr[0]);
                         result.implementsInterfacesFiles = implementsInterfaces.map(arr => arr[1]);
                     }

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -3,8 +3,8 @@ import { Class } from '../Components/Class';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace ClassFactory {
-    export function create(classSymbol: ts.Symbol, checker: ts.TypeChecker): Class {
-        const result: Class = new Class(classSymbol.getName());
+    export function create(fileName: string, classSymbol: ts.Symbol, checker: ts.TypeChecker): Class {
+        const result: Class = new Class(fileName, classSymbol.getName());
         const classDeclaration: ts.ClassDeclaration[] | undefined = <ts.ClassDeclaration[] | undefined>classSymbol.getDeclarations();
 
         if (classDeclaration !== undefined && classDeclaration.length > 0) {

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -32,13 +32,13 @@ export namespace ClassFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        const extendsClass = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
+                        const extendsClass: string[] = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
                         result.extendsClass = extendsClass[0];
                         result.extendsClassFile = extendsClass[1];
                     } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
-                        const implementsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
-                        result.implementsInterfaces = implementsInterfaces.map(arr => arr[0]);
-                        result.implementsInterfacesFiles = implementsInterfaces.map(arr => arr[1]);
+                        const implementsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        result.implementsInterfaces = implementsInterfaces.map((arr: string[]) => arr[0]);
+                        result.implementsInterfacesFiles = implementsInterfaces.map((arr: string[]) => arr[1]);
                     }
                 });
             }

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -4,7 +4,7 @@ import { ComponentFactory } from './ComponentFactory';
 
 export namespace ClassFactory {
     export function create(fileName: string, classSymbol: ts.Symbol, checker: ts.TypeChecker): Class {
-        const result: Class = new Class(fileName, classSymbol.getName());
+        const result: Class = new Class(classSymbol.getName(), fileName);
         const classDeclaration: ts.ClassDeclaration[] | undefined = <ts.ClassDeclaration[] | undefined>classSymbol.getDeclarations();
 
         if (classDeclaration !== undefined && classDeclaration.length > 0) {
@@ -32,9 +32,13 @@ export namespace ClassFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        result.extendsClass = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
+                        let extendsClass = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
+                        result.extendsClass = extendsClass[0];
+                        result.extendsClassFile = extendsClass[1];
                     } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
-                        result.implementsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        let implementsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        result.implementsInterfaces = implementsInterfaces.map(arr => arr[0]);
+                        result.implementsInterfacesFiles = implementsInterfaces.map(arr => arr[1]);
                     }
                 });
             }

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -93,11 +93,12 @@ export namespace ComponentFactory {
         return heritageClause.types.map((nodeObject: ts.ExpressionWithTypeArguments) => {
             const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
             if (symbolAtLocation !== undefined) {
-                /* tslint:disable-next-line */
+                // tslint:disable
                 let ogSymbol: any = checker.getAliasedSymbol(symbolAtLocation);
                 while (ogSymbol.parent) { ogSymbol = ogSymbol.parent; }
 
                 return [checker.getFullyQualifiedName(symbolAtLocation), ogSymbol.valueDeclaration.fileName];
+                // tslint:enable
             }
 
             return ['', ''];

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -93,6 +93,7 @@ export namespace ComponentFactory {
         return heritageClause.types.map((nodeObject: ts.ExpressionWithTypeArguments) => {
             const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
             if (symbolAtLocation !== undefined) {
+                /* tslint:disable-next-line */
                 let ogSymbol: any = checker.getAliasedSymbol(symbolAtLocation);
                 while (ogSymbol.parent) { ogSymbol = ogSymbol.parent; }
 

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -20,7 +20,7 @@ export namespace ComponentFactory {
             node.parent.kind === ts.SyntaxKind.ModuleBlock;
     }
 
-    export function create(node: ts.Node, checker: ts.TypeChecker): IComponentComposite[] {
+    export function create(fileName: string, node: ts.Node, checker: ts.TypeChecker): IComponentComposite[] {
         const componentComposites: IComponentComposite[] = [];
 
         ts.forEachChild(node, (childNode: ts.Node) => {
@@ -40,7 +40,7 @@ export namespace ComponentFactory {
                 if (classSymbol === undefined) {
                     return;
                 }
-                componentComposites.push(ClassFactory.create(classSymbol, checker));
+                componentComposites.push(ClassFactory.create(fileName, classSymbol, checker));
 
                 // No need to walk any further, class expressions/inner declarations
                 // cannot be exported
@@ -57,7 +57,7 @@ export namespace ComponentFactory {
                 if (namespaceSymbol === undefined) {
                     return;
                 }
-                componentComposites.push(NamespaceFactory.create(namespaceSymbol, checker));
+                componentComposites.push(NamespaceFactory.create(fileName, namespaceSymbol, checker));
             } else if (childNode.kind === ts.SyntaxKind.EnumDeclaration) {
                 const currentNode: ts.EnumDeclaration = <ts.EnumDeclaration>childNode;
                 const enumSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -95,6 +95,7 @@ export namespace ComponentFactory {
             if (symbolAtLocation !== undefined) {
                 let ogSymbol: any = checker.getAliasedSymbol(symbolAtLocation);
                 while (ogSymbol.parent) { ogSymbol = ogSymbol.parent; }
+
                 return [checker.getFullyQualifiedName(symbolAtLocation), ogSymbol.valueDeclaration.fileName];
             }
 

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -89,14 +89,16 @@ export namespace ComponentFactory {
         return 'public';
     }
 
-    export function getHeritageClauseNames(heritageClause: ts.HeritageClause, checker: ts.TypeChecker): string[] {
+    export function getHeritageClauseNames(heritageClause: ts.HeritageClause, checker: ts.TypeChecker): string[][] {
         return heritageClause.types.map((nodeObject: ts.ExpressionWithTypeArguments) => {
             const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
             if (symbolAtLocation !== undefined) {
-                return checker.getFullyQualifiedName(symbolAtLocation);
+                let ogSymbol: any = checker.getAliasedSymbol(symbolAtLocation);
+                while (ogSymbol.parent) { ogSymbol = ogSymbol.parent; }
+                return [checker.getFullyQualifiedName(symbolAtLocation), ogSymbol.valueDeclaration.fileName];
             }
 
-            return '';
+            return ['', ''];
         });
     }
 

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -3,8 +3,8 @@ import { File } from '../Components/File';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
-    export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
-        const file: File = new File();
+    export function create(sourceFile: ts.SourceFile, checker: ts.TypeChecker): File {
+        const file: File = new File(sourceFile.fileName);
         file.parts = ComponentFactory.create(sourceFile, checker);
 
         return file;

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -3,8 +3,8 @@ import { File } from '../Components/File';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
-    export function create(sourceFile: ts.SourceFile, checker: ts.TypeChecker): File {
-        const file: File = new File(sourceFile.fileName);
+    export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
+        const file: File = new File();
         file.parts = ComponentFactory.create(sourceFile, checker);
 
         return file;

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -3,9 +3,9 @@ import { File } from '../Components/File';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace FileFactory {
-    export function create(sourceFile: ts.Node, checker: ts.TypeChecker): File {
+    export function create(fileName: string, sourceFile: ts.Node, checker: ts.TypeChecker): File {
         const file: File = new File();
-        file.parts = ComponentFactory.create(sourceFile, checker);
+        file.parts = ComponentFactory.create(fileName, sourceFile, checker);
 
         return file;
     }

--- a/src/Factories/InterfaceFactory.ts
+++ b/src/Factories/InterfaceFactory.ts
@@ -18,9 +18,9 @@ export namespace InterfaceFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        const extendsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
-                        result.extendsInterface = extendsInterfaces.map(arr => arr[0]);
-                        result.extendsInterfaceFiles = extendsInterfaces.map(arr => arr[1]);
+                        const extendsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        result.extendsInterface = extendsInterfaces.map((arr: string[]) => arr[0]);
+                        result.extendsInterfaceFiles = extendsInterfaces.map((arr: string[]) => arr[1]);
                     }
                 });
             }

--- a/src/Factories/InterfaceFactory.ts
+++ b/src/Factories/InterfaceFactory.ts
@@ -18,7 +18,7 @@ export namespace InterfaceFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        let extendsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        const extendsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
                         result.extendsInterface = extendsInterfaces.map(arr => arr[0]);
                         result.extendsInterfaceFiles = extendsInterfaces.map(arr => arr[1]);
                     }

--- a/src/Factories/InterfaceFactory.ts
+++ b/src/Factories/InterfaceFactory.ts
@@ -18,7 +18,9 @@ export namespace InterfaceFactory {
             if (heritageClauses !== undefined) {
                 heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
                     if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        result.extendsInterface = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        let extendsInterfaces = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                        result.extendsInterface = extendsInterfaces.map(arr => arr[0]);
+                        result.extendsInterfaceFiles = extendsInterfaces.map(arr => arr[1]);
                     }
                 });
             }

--- a/src/Factories/NamespaceFactory.ts
+++ b/src/Factories/NamespaceFactory.ts
@@ -3,7 +3,7 @@ import { Namespace } from '../Components/Namespace';
 import { ComponentFactory } from './ComponentFactory';
 
 export namespace NamespaceFactory {
-    export function create(namespaceSymbol: ts.Symbol, checker: ts.TypeChecker): Namespace {
+    export function create(fileName: string, namespaceSymbol: ts.Symbol, checker: ts.TypeChecker): Namespace {
         const result: Namespace = new Namespace(namespaceSymbol.getName());
         const namespaceDeclarations: ts.NamespaceDeclaration[] | undefined =
             <ts.NamespaceDeclaration[] | undefined>namespaceSymbol.getDeclarations();
@@ -21,7 +21,7 @@ export namespace NamespaceFactory {
         if (declaration.body.kind === ts.SyntaxKind.ModuleDeclaration) {
             const childSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(declaration.body.name);
             if (childSymbol !== undefined) {
-                result.parts = [create(childSymbol, checker)];
+                result.parts = [create(fileName, childSymbol, checker)];
 
                 return result;
             }
@@ -31,7 +31,7 @@ export namespace NamespaceFactory {
             return result;
         }
 
-        result.parts = ComponentFactory.create(declaration.body, checker);
+        result.parts = ComponentFactory.create(fileName, declaration.body, checker);
 
         return result;
     }

--- a/src/tplant.ts
+++ b/src/tplant.ts
@@ -29,7 +29,7 @@ export namespace tplant {
         program.getSourceFiles()
             .forEach((sourceFile: ts.SourceFile): void => {
                 if (!sourceFile.isDeclarationFile) {
-                    const file: IComponentComposite | undefined = FileFactory.create(sourceFile, checker);
+                    const file: IComponentComposite | undefined = FileFactory.create(sourceFile.fileName, sourceFile, checker);
                     if (file !== undefined) {
                         result.push(file);
                     }


### PR DESCRIPTION
Two classes with the same name can be imported and extended/implemented from different files:

```typescript
// Class1.ts
import BaseClass from './BaseClass1.ts';
class Class1 extends BaseClass {}
```

```typescript
// Class2.ts
import BaseClass from './BaseClass2.ts';
class Class2 extends BaseClass {}
```

But calling tplant.generateDocumentation only gives names as references.

Each Class has been amended to:
1. A filename property about the file where it resides
2. the abstract extendsClassFile and implementsInterfacesFiles properties have been added to provide the necessary identification abilities.

I'm a fairly good TS dev but NOOB at the compilation API/typings so if you going to suggest something please provide alternative code.

