### PR TITLE
Populate constructor methods.

### DIFF
--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -13,6 +13,7 @@ export namespace ClassFactory {
         }
 
         if (classSymbol.members !== undefined) {
+            result.constructorMethods = ComponentFactory.serializeConstructors(classSymbol.members, checker);
             result.members = ComponentFactory.serializeMethods(classSymbol.members, checker);
             result.typeParameters = ComponentFactory.serializeTypeParameters(classSymbol.members, checker);
         }

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -131,6 +131,10 @@ export namespace ComponentFactory {
         return getOriginalFile(typeSymbol, checker);
     }
 
+    function isConstructor(declaration: ts.NamedDeclaration): boolean {
+      return declaration.kind === ts.SyntaxKind.Constructor;
+    }
+
     function isMethod(declaration: ts.NamedDeclaration): boolean {
         return declaration.kind === ts.SyntaxKind.MethodDeclaration ||
             declaration.kind === ts.SyntaxKind.MethodSignature;
@@ -185,6 +189,29 @@ export namespace ComponentFactory {
         }
 
         return false;
+    }
+
+    export function serializeConstructors(
+        memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>,
+        checker: ts.TypeChecker
+    ): (Property | Method)[] {
+      const result: (Property | Method)[] = [];
+
+      if (memberSymbols !== undefined) {
+          memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
+              const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
+              if (memberDeclarations === undefined) {
+                  return;
+              }
+              memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
+                  if (isConstructor(memberDeclaration)) {
+                      result.push(MethodFactory.create(memberSymbol, memberDeclaration, checker));
+                  }
+              });
+          });
+      }
+
+      return result;
     }
 
     export function serializeMethods(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>, checker: ts.TypeChecker): (Property | Method)[] {


### PR DESCRIPTION
Before, every class had ```constructorMethods=[]``` when calling ```tplant.generateDocumentation```. This change adds in those constructors for every type that has them.