### PR TITLE
Add readonly properties.

### DIFF
--- a/src/Components/Property.ts
+++ b/src/Components/Property.ts
@@ -11,5 +11,6 @@ export class Property extends ComponentComposite {
     public returnType: string = 'any';
     public isAbstract: boolean = false;
     public isOptional: boolean = false;
+    public isReadonly: boolean = false;
     public isStatic: boolean = false;
 }

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -8,8 +8,8 @@ export namespace ClassFactory {
         const classDeclaration: ts.ClassDeclaration[] | undefined = <ts.ClassDeclaration[] | undefined>classSymbol.getDeclarations();
 
         if (classDeclaration !== undefined && classDeclaration.length > 0) {
-            result.isStatic = ComponentFactory.isStatic(classDeclaration[classDeclaration.length - 1]);
-            result.isAbstract = ComponentFactory.isAbstract(classDeclaration[classDeclaration.length - 1]);
+            result.isStatic = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.StaticKeyword);
+            result.isAbstract = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.AbstractKeyword);
         }
 
         if (classSymbol.members !== undefined) {

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -162,27 +162,13 @@ export namespace ComponentFactory {
         return getModifier(memberModifiers);
     }
 
-    export function isAbstract(memberDeclaration: ts.Declaration): boolean {
+    export function isModifier(memberDeclaration: ts.Declaration, modifierKind: ts.SyntaxKind): boolean {
 
         const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
 
         if (memberModifiers !== undefined) {
             for (const memberModifier of memberModifiers) {
-                if (memberModifier.kind === ts.SyntaxKind.AbstractKeyword) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    export function isStatic(memberDeclaration: ts.Declaration): boolean {
-        const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
-
-        if (memberModifiers !== undefined) {
-            for (const memberModifier of memberModifiers) {
-                if (memberModifier.kind === ts.SyntaxKind.StaticKeyword) {
+                if (memberModifier.kind === modifierKind) {
                     return true;
                 }
             }

--- a/src/Factories/MethodFactory.ts
+++ b/src/Factories/MethodFactory.ts
@@ -9,9 +9,9 @@ export namespace MethodFactory {
     export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Method {
         const result: Method = new Method(signature.getName());
         result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
-        result.isAbstract = ComponentFactory.isAbstract(namedDeclaration);
+        result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
         result.isOptional = ComponentFactory.isOptional(<ts.MethodDeclaration>namedDeclaration);
-        result.isStatic = ComponentFactory.isStatic(namedDeclaration);
+        result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
         const methodSignature: ts.Signature | undefined = checker.getSignatureFromDeclaration(<ts.MethodDeclaration>namedDeclaration);
         if (methodSignature !== undefined) {
             const returnType: ts.Type = methodSignature.getReturnType();

--- a/src/Factories/PropertyFactory.ts
+++ b/src/Factories/PropertyFactory.ts
@@ -6,9 +6,10 @@ export namespace PropertyFactory {
     export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Property {
         const result: Property = new Property(signature.getName());
         result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
-        result.isAbstract = ComponentFactory.isAbstract(namedDeclaration);
+        result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
         result.isOptional = ComponentFactory.isOptional(<ts.PropertyDeclaration>namedDeclaration);
-        result.isStatic = ComponentFactory.isStatic(namedDeclaration);
+        result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
+        result.isReadonly = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.ReadonlyKeyword);
         result.returnType = checker.typeToString(
             checker.getTypeOfSymbolAtLocation(
                 signature,


### PR DESCRIPTION
Before, properties were not tagged whether or not they were readonly when calling ```tplant.generateDocumentation```. I fixed that and re-used the code from other property modifiers.