### PR TITLE
build: update to use eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "root": true,
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": { "project": ["./tsconfig.json"] },
+    "plugins": [
+        "@typescript-eslint"
+    ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,9 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '16.x'
     - run: npm install
     - run: npm run build
+    - run: npm run lint
     - run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,23 @@
         "@types/glob": "^7.1.1",
         "@types/jest": "^26.0.24",
         "@types/node": "^12.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.5.0",
+        "@typescript-eslint/parser": "^6.5.0",
+        "eslint": "^8.48.0",
         "jest": "^27.0.6",
         "ts-jest": "^27.0.3"
+      },
+      "engines": {
+        "node": "^16.0.0"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -621,6 +636,140 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -886,6 +1035,41 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1007,6 +1191,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1023,6 +1213,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -1046,6 +1242,273 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.5.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -1053,9 +1516,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1086,6 +1549,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -1105,6 +1577,22 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1166,6 +1654,15 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/asynckit": {
@@ -1551,9 +2048,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1619,6 +2116,30 @@
       "dev": true,
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/domexception": {
@@ -1706,6 +2227,274 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1717,6 +2506,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -1798,6 +2611,40 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1810,6 +2657,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -1817,6 +2673,18 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1843,6 +2711,26 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -1941,6 +2829,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1950,10 +2850,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/has": {
@@ -2043,6 +2969,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -2106,6 +3066,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2124,6 +3093,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2131,6 +3112,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3031,21 +4021,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.0.6.tgz",
@@ -3243,6 +4218,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -3256,6 +4249,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -3305,6 +4307,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -3364,6 +4372,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -3408,9 +4425,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3630,6 +4647,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -3667,6 +4696,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -3786,6 +4824,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -3835,6 +4893,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -3848,6 +4916,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -3869,6 +4960,21 @@
       "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -3990,12 +5096,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4017,6 +5123,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -4079,6 +5197,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -4179,21 +5303,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -4257,6 +5366,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz",
@@ -4284,6 +5402,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
@@ -4480,9 +5599,27 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -4935,6 +6072,99 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
+      "dev": true
+    },
+    "@eslint/eslintrc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint/js": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
+      "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -5145,6 +6375,32 @@
         "chalk": "^4.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -5263,6 +6519,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -5279,6 +6541,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -5302,6 +6570,154 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ts-api-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+          "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ts-api-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+          "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ts-api-utils": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+          "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "semver": "^7.5.4"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "6.5.0",
+        "eslint-visitor-keys": "^3.4.1"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -5309,9 +6725,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true
     },
     "acorn-globals": {
@@ -5332,6 +6748,13 @@
         }
       }
     },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+    },
     "acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -5345,6 +6768,18 @@
       "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -5389,6 +6824,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5697,9 +7138,9 @@
       }
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -5746,6 +7187,24 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "domexception": {
       "version": "2.0.1",
@@ -5807,11 +7266,215 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.48.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "globals": {
+          "version": "13.21.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+          "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+          "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+          "dev": true,
+          "requires": {
+            "@aashutoshrathi/word-wrap": "^1.2.3",
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
     },
     "estraverse": {
       "version": "5.2.0",
@@ -5870,6 +7533,36 @@
         }
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -5882,6 +7575,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -5889,6 +7591,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
@@ -5909,6 +7620,23 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
     },
     "form-data": {
       "version": "3.0.1",
@@ -5976,16 +7704,45 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "has": {
@@ -6054,6 +7811,30 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
     "import-local": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
@@ -6102,6 +7883,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -6114,10 +7901,25 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
     "is-potential-custom-element-name": {
@@ -6813,15 +8615,6 @@
             "ansi-styles": "^5.0.0",
             "react-is": "^17.0.1"
           }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -6973,6 +8766,24 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -6980,6 +8791,15 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "kleur": {
@@ -7017,6 +8837,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lru-cache": {
@@ -7066,6 +8892,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -7098,9 +8930,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7271,6 +9103,15 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -7298,6 +9139,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "picomatch": {
@@ -7393,6 +9240,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7430,6 +9283,12 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7437,6 +9296,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -7458,6 +9326,15 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
+      }
+    },
+    "semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
       }
     },
     "shebang-command": {
@@ -7554,12 +9431,12 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -7572,6 +9449,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -7619,6 +9502,12 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "throat": {
       "version": "6.0.1",
@@ -7690,15 +9579,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -7742,6 +9622,15 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "v8-to-istanbul": {
       "version": "8.0.0",
@@ -7914,6 +9803,12 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsc",
     "build:dev": "tsc --sourceMap -w",
+    "lint": "eslint src --ext .ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",
     "test": "jest"
@@ -41,19 +42,25 @@
   "dependencies": {
     "commander": "^6.1.0",
     "glob": "^7.1.6",
+    "node-plantuml": "0.9.0",
     "plantuml-encoder": "^1.4.0",
-    "typescript": "4.0.3",
-    "node-plantuml": "0.9.0"
+    "typescript": "4.0.3"
   },
   "devDependencies": {
     "@types/glob": "^7.1.1",
     "@types/jest": "^26.0.24",
     "@types/node": "^12.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
+    "eslint": "^8.48.0",
     "jest": "^27.0.6",
     "ts-jest": "^27.0.3"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node"
+  },
+  "engines": {
+    "node": "^16.0.0"
   }
 }

--- a/src/Factories/ClassFactory.ts
+++ b/src/Factories/ClassFactory.ts
@@ -1,50 +1,48 @@
 import ts from 'typescript';
 import { Class } from '../Components/Class';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace ClassFactory {
-    export function create(fileName: string, classSymbol: ts.Symbol, checker: ts.TypeChecker): Class {
-        const result: Class = new Class(classSymbol.getName(), fileName);
-        const classDeclaration: ts.ClassDeclaration[] | undefined = <ts.ClassDeclaration[] | undefined>classSymbol.getDeclarations();
+export function create(fileName: string, classSymbol: ts.Symbol, checker: ts.TypeChecker): Class {
+    const result: Class = new Class(classSymbol.getName(), fileName);
+    const classDeclaration: ts.ClassDeclaration[] | undefined = <ts.ClassDeclaration[] | undefined>classSymbol.getDeclarations();
 
-        if (classDeclaration !== undefined && classDeclaration.length > 0) {
-            result.isStatic = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.StaticKeyword);
-            result.isAbstract = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.AbstractKeyword);
-        }
-
-        if (classSymbol.members !== undefined) {
-            result.constructorMethods = ComponentFactory.serializeConstructors(classSymbol.members, checker);
-            result.members = ComponentFactory.serializeMethods(classSymbol.members, checker);
-            result.typeParameters = ComponentFactory.serializeTypeParameters(classSymbol.members, checker);
-        }
-
-        if (classSymbol.exports !== undefined) {
-            result.members = result.members.concat(ComponentFactory.serializeMethods(classSymbol.exports, checker));
-        }
-
-        if (classSymbol.globalExports !== undefined) {
-            result.members = result.members.concat(ComponentFactory.serializeMethods(classSymbol.globalExports, checker));
-        }
-
-        if (classDeclaration !== undefined && classDeclaration.length > 0) {
-            const heritageClauses: ts.NodeArray<ts.HeritageClause> | undefined =
-                classDeclaration[classDeclaration.length - 1].heritageClauses;
-
-            if (heritageClauses !== undefined) {
-                heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
-                    if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        const extendsClass: string[] = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
-                        result.extendsClass = extendsClass[0];
-                        result.extendsClassFile = extendsClass[1];
-                    } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
-                        const implementsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
-                        result.implementsInterfaces = implementsInterfaces.map((arr: string[]) => arr[0]);
-                        result.implementsInterfacesFiles = implementsInterfaces.map((arr: string[]) => arr[1]);
-                    }
-                });
-            }
-        }
-
-        return result;
+    if (classDeclaration !== undefined && classDeclaration.length > 0) {
+        result.isStatic = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.StaticKeyword);
+        result.isAbstract = ComponentFactory.isModifier(classDeclaration[classDeclaration.length - 1], ts.SyntaxKind.AbstractKeyword);
     }
+
+    if (classSymbol.members !== undefined) {
+        result.constructorMethods = ComponentFactory.serializeConstructors(classSymbol.members, checker);
+        result.members = ComponentFactory.serializeMethods(classSymbol.members, checker);
+        result.typeParameters = ComponentFactory.serializeTypeParameters(classSymbol.members, checker);
+    }
+
+    if (classSymbol.exports !== undefined) {
+        result.members = result.members.concat(ComponentFactory.serializeMethods(classSymbol.exports, checker));
+    }
+
+    if (classSymbol.globalExports !== undefined) {
+        result.members = result.members.concat(ComponentFactory.serializeMethods(classSymbol.globalExports, checker));
+    }
+
+    if (classDeclaration !== undefined && classDeclaration.length > 0) {
+        const heritageClauses: ts.NodeArray<ts.HeritageClause> | undefined =
+            classDeclaration[classDeclaration.length - 1].heritageClauses;
+
+        if (heritageClauses !== undefined) {
+            heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
+                if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
+                    const extendsClass: string[] = ComponentFactory.getHeritageClauseNames(heritageClause, checker)[0];
+                    result.extendsClass = extendsClass[0];
+                    result.extendsClassFile = extendsClass[1];
+                } else if (heritageClause.token === ts.SyntaxKind.ImplementsKeyword) {
+                    const implementsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                    result.implementsInterfaces = implementsInterfaces.map((arr: string[]) => arr[0]);
+                    result.implementsInterfacesFiles = implementsInterfaces.map((arr: string[]) => arr[1]);
+                }
+            });
+        }
+    }
+
+    return result;
 }

--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -4,259 +4,255 @@ import { Property } from '../Components/Property';
 import { TypeParameter } from '../Components/TypeParameter';
 import { IComponentComposite } from '../Models/IComponentComposite';
 import { Modifier } from '../Models/Modifier';
-import { ClassFactory } from './ClassFactory';
-import { EnumFactory } from './EnumFactory';
-import { InterfaceFactory } from './InterfaceFactory';
-import { MethodFactory } from './MethodFactory';
-import { NamespaceFactory } from './NamespaceFactory';
-import { PropertyFactory } from './PropertyFactory';
-import { TypeParameterFactory } from './TypeParameterFactory';
+import * as ClassFactory from './ClassFactory';
+import * as EnumFactory from './EnumFactory';
+import * as InterfaceFactory from './InterfaceFactory';
+import * as MethodFactory from './MethodFactory';
+import * as NamespaceFactory from './NamespaceFactory';
+import * as PropertyFactory from './PropertyFactory';
+import * as TypeParameterFactory from './TypeParameterFactory';
 
-export namespace ComponentFactory {
-    export function isNodeExported(node: ts.Node): boolean {
-        // tslint:disable-next-line no-bitwise
-        return (node.flags & ts.ModifierFlags.Export) !== 0 ||
-            node.parent.kind === ts.SyntaxKind.SourceFile ||
-            node.parent.kind === ts.SyntaxKind.ModuleBlock;
-    }
+export function isNodeExported(node: ts.Node): boolean {
+    return (node.flags & ts.ModifierFlags.Export) !== 0 ||
+        node.parent.kind === ts.SyntaxKind.SourceFile ||
+        node.parent.kind === ts.SyntaxKind.ModuleBlock;
+}
 
-    export function create(fileName: string, node: ts.Node, checker: ts.TypeChecker): IComponentComposite[] {
-        const componentComposites: IComponentComposite[] = [];
+export function create(fileName: string, node: ts.Node, checker: ts.TypeChecker): IComponentComposite[] {
+    const componentComposites: IComponentComposite[] = [];
 
-        ts.forEachChild(node, (childNode: ts.Node) => {
+    ts.forEachChild(node, (childNode: ts.Node) => {
 
-            // Only consider exported nodes
-            if (!isNodeExported(childNode)) {
-                return;
-            }
-
-            if (childNode.kind === ts.SyntaxKind.ClassDeclaration) {
-            const currentNode: ts.ClassLikeDeclarationBase = <ts.ClassLikeDeclarationBase>childNode;
-            if (currentNode.name === undefined) {
-              return;
-            }
-            // This is a top level class, get its symbol
-            const classSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
-            if (classSymbol === undefined) {
-              return;
-            }
-            componentComposites.push(ClassFactory.create(fileName, classSymbol, checker));
-
-            // No need to walk any further, class expressions/inner declarations
-            // cannot be exported
-          } else if (childNode.kind === ts.SyntaxKind.InterfaceDeclaration) {
-            const currentNode: ts.InterfaceDeclaration = <ts.InterfaceDeclaration>childNode;
-            const interfaceSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
-            if (interfaceSymbol === undefined) {
-              return;
-            }
-            componentComposites.push(InterfaceFactory.create(interfaceSymbol, checker));
-          } else if (childNode.kind === ts.SyntaxKind.ModuleDeclaration) {
-            const currentNode: ts.NamespaceDeclaration = <ts.NamespaceDeclaration>childNode;
-            const namespaceSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
-            if (namespaceSymbol === undefined) {
-              return;
-            }
-            componentComposites.push(NamespaceFactory.create(fileName, namespaceSymbol, checker));
-          } else if (childNode.kind === ts.SyntaxKind.EnumDeclaration) {
-            const currentNode: ts.EnumDeclaration = <ts.EnumDeclaration>childNode;
-            const enumSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
-            if (enumSymbol === undefined) {
-              return;
-            }
-            componentComposites.push(EnumFactory.create(enumSymbol));
-
+        // Only consider exported nodes
+        if (!isNodeExported(childNode)) {
             return;
-          } else if (childNode.kind === ts.SyntaxKind.FunctionDeclaration) {
-            const currentNode: ts.FunctionDeclaration = <ts.FunctionDeclaration>childNode;
-            if (currentNode.name === undefined) {
-              return;
-            }
-            const functionSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
-            if (functionSymbol === undefined) {
-              return;
-            }
-            componentComposites.push(MethodFactory.create(functionSymbol, currentNode, checker));
-          }
-        });
-
-        return componentComposites;
-    }
-
-    function getModifier(modifiers: ts.NodeArray<ts.Modifier>): Modifier {
-        for (const modifier of modifiers) {
-            if (modifier.kind === ts.SyntaxKind.PrivateKeyword) {
-                return 'private';
-            }
-            if (modifier.kind === ts.SyntaxKind.PublicKeyword) {
-                return 'public';
-            }
-            if (modifier.kind === ts.SyntaxKind.ProtectedKeyword) {
-                return 'protected';
-            }
         }
 
+        if (childNode.kind === ts.SyntaxKind.ClassDeclaration) {
+        const currentNode: ts.ClassLikeDeclarationBase = <ts.ClassLikeDeclarationBase>childNode;
+        if (currentNode.name === undefined) {
+          return;
+        }
+        // This is a top level class, get its symbol
+        const classSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
+        if (classSymbol === undefined) {
+          return;
+        }
+        componentComposites.push(ClassFactory.create(fileName, classSymbol, checker));
+
+        // No need to walk any further, class expressions/inner declarations
+        // cannot be exported
+      } else if (childNode.kind === ts.SyntaxKind.InterfaceDeclaration) {
+        const currentNode: ts.InterfaceDeclaration = <ts.InterfaceDeclaration>childNode;
+        const interfaceSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
+        if (interfaceSymbol === undefined) {
+          return;
+        }
+        componentComposites.push(InterfaceFactory.create(interfaceSymbol, checker));
+      } else if (childNode.kind === ts.SyntaxKind.ModuleDeclaration) {
+        const currentNode: ts.NamespaceDeclaration = <ts.NamespaceDeclaration>childNode;
+        const namespaceSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
+        if (namespaceSymbol === undefined) {
+          return;
+        }
+        componentComposites.push(NamespaceFactory.create(fileName, namespaceSymbol, checker));
+      } else if (childNode.kind === ts.SyntaxKind.EnumDeclaration) {
+        const currentNode: ts.EnumDeclaration = <ts.EnumDeclaration>childNode;
+        const enumSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
+        if (enumSymbol === undefined) {
+          return;
+        }
+        componentComposites.push(EnumFactory.create(enumSymbol));
+
+        return;
+      } else if (childNode.kind === ts.SyntaxKind.FunctionDeclaration) {
+        const currentNode: ts.FunctionDeclaration = <ts.FunctionDeclaration>childNode;
+        if (currentNode.name === undefined) {
+          return;
+        }
+        const functionSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(currentNode.name);
+        if (functionSymbol === undefined) {
+          return;
+        }
+        componentComposites.push(MethodFactory.create(functionSymbol, currentNode, checker));
+      }
+    });
+
+    return componentComposites;
+}
+
+function getModifier(modifiers: ts.NodeArray<ts.Modifier>): Modifier {
+    for (const modifier of modifiers) {
+        if (modifier.kind === ts.SyntaxKind.PrivateKeyword) {
+            return 'private';
+        }
+        if (modifier.kind === ts.SyntaxKind.PublicKeyword) {
+            return 'public';
+        }
+        if (modifier.kind === ts.SyntaxKind.ProtectedKeyword) {
+            return 'protected';
+        }
+    }
+
+    return 'public';
+}
+
+export function getHeritageClauseNames(heritageClause: ts.HeritageClause, checker: ts.TypeChecker): string[][] {
+    return heritageClause.types.map((nodeObject: ts.ExpressionWithTypeArguments) => {
+        const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
+        if (symbolAtLocation !== undefined) {
+            const ogFile: string = getOriginalFile(symbolAtLocation, checker);
+
+            return [checker.getFullyQualifiedName(symbolAtLocation), ogFile];
+        }
+
+        return ['', ''];
+    });
+}
+
+function getOriginalFile(typeSymbol: ts.Symbol, checker: ts.TypeChecker): string {
+    let deAliasSymbol: ts.Symbol;
+
+    if ((typeSymbol.flags & ts.SymbolFlags.Alias) !== 0) {
+        deAliasSymbol = checker.getAliasedSymbol(typeSymbol);
+    } else {
+        deAliasSymbol = typeSymbol;
+    }
+
+    return deAliasSymbol.declarations?.[0].getSourceFile().fileName;
+}
+
+export function getOriginalFileOriginalType(tsType: ts.Type, checker: ts.TypeChecker): string {
+    if (tsType === undefined || checker === undefined) { return ''; }
+
+    let deParameterType: ts.Type = tsType;
+    let typeSymbol: ts.Symbol | undefined = tsType.getSymbol();
+
+    while (typeSymbol?.name === 'Array') {
+        deParameterType = checker.getTypeArguments(<ts.TypeReference>deParameterType)[0];
+        typeSymbol = deParameterType.getSymbol();
+    }
+
+    if (typeSymbol === undefined) { return ''; }
+
+    return getOriginalFile(typeSymbol, checker);
+}
+
+function isConstructor(declaration: ts.NamedDeclaration): boolean {
+  return declaration.kind === ts.SyntaxKind.Constructor;
+}
+
+function isMethod(declaration: ts.NamedDeclaration): boolean {
+    return declaration.kind === ts.SyntaxKind.MethodDeclaration ||
+        declaration.kind === ts.SyntaxKind.MethodSignature;
+}
+
+function isProperty(declaration: ts.NamedDeclaration): boolean {
+    return declaration.kind === ts.SyntaxKind.PropertySignature ||
+        declaration.kind === ts.SyntaxKind.PropertyDeclaration ||
+        declaration.kind === ts.SyntaxKind.GetAccessor ||
+        declaration.kind === ts.SyntaxKind.SetAccessor ||
+        declaration.kind === ts.SyntaxKind.Parameter;
+}
+
+function isTypeParameter(declaration: ts.NamedDeclaration): boolean {
+    return declaration.kind === ts.SyntaxKind.TypeParameter;
+}
+
+export function getMemberModifier(memberDeclaration: ts.Declaration): Modifier {
+    const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
+
+    if (memberModifiers === undefined) {
         return 'public';
     }
 
-    export function getHeritageClauseNames(heritageClause: ts.HeritageClause, checker: ts.TypeChecker): string[][] {
-        return heritageClause.types.map((nodeObject: ts.ExpressionWithTypeArguments) => {
-            const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
-            if (symbolAtLocation !== undefined) {
-                const ogFile: string = getOriginalFile(symbolAtLocation, checker);
+    return getModifier(memberModifiers);
+}
 
-                return [checker.getFullyQualifiedName(symbolAtLocation), ogFile];
+export function isModifier(memberDeclaration: ts.Declaration, modifierKind: ts.SyntaxKind): boolean {
+
+    const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
+
+    if (memberModifiers !== undefined) {
+        for (const memberModifier of memberModifiers) {
+            if (memberModifier.kind === modifierKind) {
+                return true;
             }
+        }
+    }
 
-            return ['', ''];
+    return false;
+}
+
+export function serializeConstructors(
+    memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>,
+    checker: ts.TypeChecker
+): (Property | Method)[] {
+  const result: (Property | Method)[] = [];
+
+  if (memberSymbols !== undefined) {
+      memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
+          const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
+          if (memberDeclarations === undefined) {
+              return;
+          }
+          memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
+              if (isConstructor(memberDeclaration)) {
+                  result.push(MethodFactory.create(memberSymbol, memberDeclaration, checker));
+              }
+          });
+      });
+  }
+
+  return result;
+}
+
+export function serializeMethods(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>, checker: ts.TypeChecker): (Property | Method)[] {
+    const result: (Property | Method)[] = [];
+
+    if (memberSymbols !== undefined) {
+        memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
+            const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
+            if (memberDeclarations === undefined) {
+                return;
+            }
+            memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
+                if (isMethod(memberDeclaration)) {
+                    result.push(MethodFactory.create(memberSymbol, memberDeclaration, checker));
+                } else if (isProperty(memberDeclaration)) {
+                    result.push(PropertyFactory.create(memberSymbol, memberDeclaration, checker));
+                }
+            });
         });
     }
 
-    function getOriginalFile(typeSymbol: ts.Symbol, checker: ts.TypeChecker): string {
-        let deAliasSymbol: ts.Symbol;
+    return result;
+}
 
-        // tslint:disable-next-line:no-bitwise
-        if ((typeSymbol.flags & ts.SymbolFlags.Alias) !== 0) {
-            deAliasSymbol = checker.getAliasedSymbol(typeSymbol);
-        } else {
-            deAliasSymbol = typeSymbol;
-        }
+export function serializeTypeParameters(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>, checker: ts.TypeChecker): TypeParameter[] {
+    const result: TypeParameter[] = [];
 
-        return deAliasSymbol.declarations?.[0].getSourceFile().fileName;
-    }
-
-    export function getOriginalFileOriginalType(tsType: ts.Type, checker: ts.TypeChecker): string {
-        if (tsType === undefined || checker === undefined) { return ''; }
-
-        let deParameterType: ts.Type = tsType;
-        let typeSymbol: ts.Symbol | undefined = tsType.getSymbol();
-
-        while (typeSymbol?.name === 'Array') {
-            deParameterType = checker.getTypeArguments(<ts.TypeReference>deParameterType)[0];
-            typeSymbol = deParameterType.getSymbol();
-        }
-
-        if (typeSymbol === undefined) { return ''; }
-
-        return getOriginalFile(typeSymbol, checker);
-    }
-
-    function isConstructor(declaration: ts.NamedDeclaration): boolean {
-      return declaration.kind === ts.SyntaxKind.Constructor;
-    }
-
-    function isMethod(declaration: ts.NamedDeclaration): boolean {
-        return declaration.kind === ts.SyntaxKind.MethodDeclaration ||
-            declaration.kind === ts.SyntaxKind.MethodSignature;
-    }
-
-    function isProperty(declaration: ts.NamedDeclaration): boolean {
-        return declaration.kind === ts.SyntaxKind.PropertySignature ||
-            declaration.kind === ts.SyntaxKind.PropertyDeclaration ||
-            declaration.kind === ts.SyntaxKind.GetAccessor ||
-            declaration.kind === ts.SyntaxKind.SetAccessor ||
-            declaration.kind === ts.SyntaxKind.Parameter;
-    }
-
-    function isTypeParameter(declaration: ts.NamedDeclaration): boolean {
-        return declaration.kind === ts.SyntaxKind.TypeParameter;
-    }
-
-    export function getMemberModifier(memberDeclaration: ts.Declaration): Modifier {
-        const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
-
-        if (memberModifiers === undefined) {
-            return 'public';
-        }
-
-        return getModifier(memberModifiers);
-    }
-
-    export function isModifier(memberDeclaration: ts.Declaration, modifierKind: ts.SyntaxKind): boolean {
-
-        const memberModifiers: ts.NodeArray<ts.Modifier> | undefined = memberDeclaration.modifiers;
-
-        if (memberModifiers !== undefined) {
-            for (const memberModifier of memberModifiers) {
-                if (memberModifier.kind === modifierKind) {
-                    return true;
-                }
+    if (memberSymbols !== undefined) {
+        memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
+            const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
+            if (memberDeclarations === undefined) {
+                return;
             }
-        }
-
-        return false;
-    }
-
-    export function serializeConstructors(
-        memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>,
-        checker: ts.TypeChecker
-    ): (Property | Method)[] {
-      const result: (Property | Method)[] = [];
-
-      if (memberSymbols !== undefined) {
-          memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
-              const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
-              if (memberDeclarations === undefined) {
-                  return;
-              }
-              memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
-                  if (isConstructor(memberDeclaration)) {
-                      result.push(MethodFactory.create(memberSymbol, memberDeclaration, checker));
-                  }
-              });
-          });
-      }
-
-      return result;
-    }
-
-    export function serializeMethods(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>, checker: ts.TypeChecker): (Property | Method)[] {
-        const result: (Property | Method)[] = [];
-
-        if (memberSymbols !== undefined) {
-            memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
-                const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
-                if (memberDeclarations === undefined) {
-                    return;
+            memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
+                if (isTypeParameter(memberDeclaration)) {
+                    result.push(TypeParameterFactory.create(memberSymbol, memberDeclaration, checker));
                 }
-                memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
-                    if (isMethod(memberDeclaration)) {
-                        result.push(MethodFactory.create(memberSymbol, memberDeclaration, checker));
-                    } else if (isProperty(memberDeclaration)) {
-                        result.push(PropertyFactory.create(memberSymbol, memberDeclaration, checker));
-                    }
-                });
             });
-        }
-
-        return result;
+        });
     }
 
-    export function serializeTypeParameters(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>, checker: ts.TypeChecker): TypeParameter[] {
-        const result: TypeParameter[] = [];
+    return result;
+}
 
-        if (memberSymbols !== undefined) {
-            memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
-                const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
-                if (memberDeclarations === undefined) {
-                    return;
-                }
-                memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
-                    if (isTypeParameter(memberDeclaration)) {
-                        result.push(TypeParameterFactory.create(memberSymbol, memberDeclaration, checker));
-                    }
-                });
-            });
-        }
+export function hasInitializer(declaration: ts.ParameterDeclaration): boolean {
+    return declaration.initializer !== undefined;
+}
 
-        return result;
-    }
-
-    export function hasInitializer(declaration: ts.ParameterDeclaration): boolean {
-        return declaration.initializer !== undefined;
-    }
-
-    export function isOptional(declaration: ts.PropertyDeclaration | ts.ParameterDeclaration | ts.MethodDeclaration): boolean {
-        return declaration.questionToken !== undefined;
-    }
+export function isOptional(declaration: ts.PropertyDeclaration | ts.ParameterDeclaration | ts.MethodDeclaration): boolean {
+    return declaration.questionToken !== undefined;
 }

--- a/src/Factories/EnumFactory.ts
+++ b/src/Factories/EnumFactory.ts
@@ -1,36 +1,34 @@
 import ts from 'typescript';
 import { Enum } from '../Components/Enum';
 import { IComponentComposite } from '../Models/IComponentComposite';
-import { EnumValueFactory } from './EnumValueFactory';
+import * as EnumValueFactory from './EnumValueFactory';
 
-export namespace EnumFactory {
-    export function create(enumSymbol: ts.Symbol): Enum {
-        const result: Enum = new Enum(enumSymbol.getName());
+export function create(enumSymbol: ts.Symbol): Enum {
+    const result: Enum = new Enum(enumSymbol.getName());
 
-        if (enumSymbol.exports !== undefined) {
-            result.values = serializeEnumProperties(enumSymbol.exports);
-        }
-
-        return result;
+    if (enumSymbol.exports !== undefined) {
+        result.values = serializeEnumProperties(enumSymbol.exports);
     }
 
-    function serializeEnumProperties(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>): IComponentComposite[] {
-        const result: IComponentComposite[] = [];
+    return result;
+}
 
-        if (memberSymbols !== undefined) {
-            memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
-                const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
-                if (memberDeclarations === undefined) {
-                    return;
+function serializeEnumProperties(memberSymbols: ts.UnderscoreEscapedMap<ts.Symbol>): IComponentComposite[] {
+    const result: IComponentComposite[] = [];
+
+    if (memberSymbols !== undefined) {
+        memberSymbols.forEach((memberSymbol: ts.Symbol): void => {
+            const memberDeclarations: ts.NamedDeclaration[] | undefined = memberSymbol.getDeclarations();
+            if (memberDeclarations === undefined) {
+                return;
+            }
+            memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
+                if (memberDeclaration.kind === ts.SyntaxKind.EnumMember) {
+                    result.push(EnumValueFactory.create(memberSymbol));
                 }
-                memberDeclarations.forEach((memberDeclaration: ts.NamedDeclaration): void => {
-                    if (memberDeclaration.kind === ts.SyntaxKind.EnumMember) {
-                        result.push(EnumValueFactory.create(memberSymbol));
-                    }
-                });
             });
-        }
-
-        return result;
+        });
     }
+
+    return result;
 }

--- a/src/Factories/EnumValueFactory.ts
+++ b/src/Factories/EnumValueFactory.ts
@@ -1,8 +1,6 @@
 import ts from 'typescript';
 import { EnumValue } from '../Components/EnumValue';
 
-export namespace EnumValueFactory {
-    export function create(signature: ts.Symbol): EnumValue {
-        return new EnumValue(signature.getName());
-    }
+export function create(signature: ts.Symbol): EnumValue {
+    return new EnumValue(signature.getName());
 }

--- a/src/Factories/FileFactory.ts
+++ b/src/Factories/FileFactory.ts
@@ -1,12 +1,10 @@
 import ts from 'typescript';
 import { File } from '../Components/File';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace FileFactory {
-    export function create(fileName: string, sourceFile: ts.SourceFile, checker: ts.TypeChecker): File {
-        const file: File = new File(sourceFile.fileName);
-        file.parts = ComponentFactory.create(fileName, sourceFile, checker);
+export function create(fileName: string, sourceFile: ts.SourceFile, checker: ts.TypeChecker): File {
+    const file: File = new File(sourceFile.fileName);
+    file.parts = ComponentFactory.create(fileName, sourceFile, checker);
 
-        return file;
-    }
+    return file;
 }

--- a/src/Factories/InterfaceFactory.ts
+++ b/src/Factories/InterfaceFactory.ts
@@ -1,31 +1,29 @@
 import ts from 'typescript';
 import { Interface } from '../Components/Interface';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace InterfaceFactory {
-    export function create(interfaceSymbol: ts.Symbol, checker: ts.TypeChecker): Interface {
-        const result: Interface = new Interface(interfaceSymbol.getName());
+export function create(interfaceSymbol: ts.Symbol, checker: ts.TypeChecker): Interface {
+    const result: Interface = new Interface(interfaceSymbol.getName());
 
-        const declaration: ts.InterfaceDeclaration[] | undefined = <ts.InterfaceDeclaration[] | undefined>interfaceSymbol.getDeclarations();
+    const declaration: ts.InterfaceDeclaration[] | undefined = <ts.InterfaceDeclaration[] | undefined>interfaceSymbol.getDeclarations();
 
-        if (interfaceSymbol.members !== undefined) {
-            result.members = ComponentFactory.serializeMethods(interfaceSymbol.members, checker);
-            result.typeParameters = ComponentFactory.serializeTypeParameters(interfaceSymbol.members, checker);
-        }
-
-        if (declaration !== undefined && declaration.length > 0) {
-            const heritageClauses: ts.NodeArray<ts.HeritageClause> | undefined = declaration[declaration.length - 1].heritageClauses;
-            if (heritageClauses !== undefined) {
-                heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
-                    if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
-                        const extendsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
-                        result.extendsInterface = extendsInterfaces.map((arr: string[]) => arr[0]);
-                        result.extendsInterfaceFiles = extendsInterfaces.map((arr: string[]) => arr[1]);
-                    }
-                });
-            }
-        }
-
-        return result;
+    if (interfaceSymbol.members !== undefined) {
+        result.members = ComponentFactory.serializeMethods(interfaceSymbol.members, checker);
+        result.typeParameters = ComponentFactory.serializeTypeParameters(interfaceSymbol.members, checker);
     }
+
+    if (declaration !== undefined && declaration.length > 0) {
+        const heritageClauses: ts.NodeArray<ts.HeritageClause> | undefined = declaration[declaration.length - 1].heritageClauses;
+        if (heritageClauses !== undefined) {
+            heritageClauses.forEach((heritageClause: ts.HeritageClause): void => {
+                if (heritageClause.token === ts.SyntaxKind.ExtendsKeyword) {
+                    const extendsInterfaces: string[][] = ComponentFactory.getHeritageClauseNames(heritageClause, checker);
+                    result.extendsInterface = extendsInterfaces.map((arr: string[]) => arr[0]);
+                    result.extendsInterfaceFiles = extendsInterfaces.map((arr: string[]) => arr[1]);
+                }
+            });
+        }
+    }
+
+    return result;
 }

--- a/src/Factories/MethodFactory.ts
+++ b/src/Factories/MethodFactory.ts
@@ -1,34 +1,32 @@
 import ts from 'typescript';
 import { Method } from '../Components/Method';
 import { Parameter } from '../Components/Parameter';
-import { ComponentFactory } from './ComponentFactory';
-import { ParameterFactory } from './ParameterFactory';
-import { TypeParameterFactory } from './TypeParameterFactory';
+import * as ComponentFactory from './ComponentFactory';
+import * as ParameterFactory from './ParameterFactory';
+import * as TypeParameterFactory from './TypeParameterFactory';
 
-export namespace MethodFactory {
-    export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Method {
-        const result: Method = new Method(signature.getName());
-        result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
-        result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
-        result.isOptional = ComponentFactory.isOptional(<ts.MethodDeclaration>namedDeclaration);
-        result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
-        result.isAsync = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AsyncKeyword);
-        const methodSignature: ts.Signature | undefined = checker.getSignatureFromDeclaration(<ts.MethodDeclaration>namedDeclaration);
-        if (methodSignature !== undefined) {
-            const returnType: ts.Type = methodSignature.getReturnType();
-            result.returnType = checker.typeToString(returnType, namedDeclaration);
-            result.returnTypeFile = ComponentFactory.getOriginalFileOriginalType(returnType, checker);
-            result.parameters = methodSignature.parameters
-                .map((parameter: ts.Symbol): Parameter => ParameterFactory.create(parameter, checker));
-            if (methodSignature.typeParameters !== undefined) {
-                result.typeParameters = methodSignature.typeParameters
-                    .map(
-                        (typeParameter: ts.TypeParameter) =>
-                        TypeParameterFactory.create(typeParameter.symbol, typeParameter.symbol.declarations[0], checker)
-                    );
-            }
+export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Method {
+    const result: Method = new Method(signature.getName());
+    result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
+    result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
+    result.isOptional = ComponentFactory.isOptional(<ts.MethodDeclaration>namedDeclaration);
+    result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
+    result.isAsync = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AsyncKeyword);
+    const methodSignature: ts.Signature | undefined = checker.getSignatureFromDeclaration(<ts.MethodDeclaration>namedDeclaration);
+    if (methodSignature !== undefined) {
+        const returnType: ts.Type = methodSignature.getReturnType();
+        result.returnType = checker.typeToString(returnType, namedDeclaration);
+        result.returnTypeFile = ComponentFactory.getOriginalFileOriginalType(returnType, checker);
+        result.parameters = methodSignature.parameters
+            .map((parameter: ts.Symbol): Parameter => ParameterFactory.create(parameter, checker));
+        if (methodSignature.typeParameters !== undefined) {
+            result.typeParameters = methodSignature.typeParameters
+                .map(
+                    (typeParameter: ts.TypeParameter) =>
+                    TypeParameterFactory.create(typeParameter.symbol, typeParameter.symbol.declarations[0], checker)
+                );
         }
-
-        return result;
     }
+
+    return result;
 }

--- a/src/Factories/NamespaceFactory.ts
+++ b/src/Factories/NamespaceFactory.ts
@@ -1,38 +1,36 @@
 import ts from 'typescript';
 import { Namespace } from '../Components/Namespace';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace NamespaceFactory {
-    export function create(fileName: string, namespaceSymbol: ts.Symbol, checker: ts.TypeChecker): Namespace {
-        const result: Namespace = new Namespace(namespaceSymbol.getName());
-        const namespaceDeclarations: ts.NamespaceDeclaration[] | undefined =
-            <ts.NamespaceDeclaration[] | undefined>namespaceSymbol.getDeclarations();
+export function create(fileName: string, namespaceSymbol: ts.Symbol, checker: ts.TypeChecker): Namespace {
+    const result: Namespace = new Namespace(namespaceSymbol.getName());
+    const namespaceDeclarations: ts.NamespaceDeclaration[] | undefined =
+        <ts.NamespaceDeclaration[] | undefined>namespaceSymbol.getDeclarations();
 
-        if (namespaceDeclarations === undefined) {
-            return result;
-        }
-
-        const declaration: ts.NamespaceDeclaration | undefined = namespaceDeclarations[namespaceDeclarations.length - 1];
-
-        if (declaration === undefined || declaration.body === undefined) {
-            return result;
-        }
-
-        if (declaration.body.kind === ts.SyntaxKind.ModuleDeclaration) {
-            const childSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(declaration.body.name);
-            if (childSymbol !== undefined) {
-                result.parts = [create(fileName, childSymbol, checker)];
-
-                return result;
-            }
-        }
-
-        if ((<ts.ModuleBlock>declaration.body).statements === undefined) {
-            return result;
-        }
-
-        result.parts = ComponentFactory.create(fileName, declaration.body, checker);
-
+    if (namespaceDeclarations === undefined) {
         return result;
     }
+
+    const declaration: ts.NamespaceDeclaration | undefined = namespaceDeclarations[namespaceDeclarations.length - 1];
+
+    if (declaration === undefined || declaration.body === undefined) {
+        return result;
+    }
+
+    if (declaration.body.kind === ts.SyntaxKind.ModuleDeclaration) {
+        const childSymbol: ts.Symbol | undefined = checker.getSymbolAtLocation(declaration.body.name);
+        if (childSymbol !== undefined) {
+            result.parts = [create(fileName, childSymbol, checker)];
+
+            return result;
+        }
+    }
+
+    if ((<ts.ModuleBlock>declaration.body).statements === undefined) {
+        return result;
+    }
+
+    result.parts = ComponentFactory.create(fileName, declaration.body, checker);
+
+    return result;
 }

--- a/src/Factories/ParameterFactory.ts
+++ b/src/Factories/ParameterFactory.ts
@@ -1,29 +1,27 @@
 import ts from 'typescript';
 import { Parameter } from '../Components/Parameter';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace ParameterFactory {
-    export function create(parameterSymbol: ts.Symbol, checker: ts.TypeChecker): Parameter {
-        const result: Parameter = new Parameter(parameterSymbol.getName());
-        const declarations: ts.ParameterDeclaration[] | undefined = <ts.ParameterDeclaration[]>parameterSymbol.getDeclarations();
-        let declaration: ts.ParameterDeclaration | undefined;
-        if (declarations !== undefined) {
-            result.hasInitializer = ComponentFactory.hasInitializer(declarations[0]);
-            result.isOptional = ComponentFactory.isOptional(declarations[0]);
-            declaration = declarations[0];
-        }
-
-        const typeOfSymbol: ts.Type = checker.getTypeOfSymbolAtLocation(
-            parameterSymbol,
-            parameterSymbol.valueDeclaration
-        );
-        result.parameterType = checker.typeToString(
-            typeOfSymbol,
-            declaration
-        );
-
-        result.parameterTypeFile = ComponentFactory.getOriginalFileOriginalType(typeOfSymbol, checker);
-
-        return result;
+export function create(parameterSymbol: ts.Symbol, checker: ts.TypeChecker): Parameter {
+    const result: Parameter = new Parameter(parameterSymbol.getName());
+    const declarations: ts.ParameterDeclaration[] | undefined = <ts.ParameterDeclaration[]>parameterSymbol.getDeclarations();
+    let declaration: ts.ParameterDeclaration | undefined;
+    if (declarations !== undefined) {
+        result.hasInitializer = ComponentFactory.hasInitializer(declarations[0]);
+        result.isOptional = ComponentFactory.isOptional(declarations[0]);
+        declaration = declarations[0];
     }
+
+    const typeOfSymbol: ts.Type = checker.getTypeOfSymbolAtLocation(
+        parameterSymbol,
+        parameterSymbol.valueDeclaration
+    );
+    result.parameterType = checker.typeToString(
+        typeOfSymbol,
+        declaration
+    );
+
+    result.parameterTypeFile = ComponentFactory.getOriginalFileOriginalType(typeOfSymbol, checker);
+
+    return result;
 }

--- a/src/Factories/PropertyFactory.ts
+++ b/src/Factories/PropertyFactory.ts
@@ -1,23 +1,21 @@
 import ts from 'typescript';
 import { Property } from '../Components/Property';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace PropertyFactory {
-    export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Property {
-        const result: Property = new Property(signature.getName());
-        result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
-        result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
-        result.isOptional = ComponentFactory.isOptional(<ts.PropertyDeclaration>namedDeclaration);
-        result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
-        result.isReadonly = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.ReadonlyKeyword);
-        result.returnType = checker.typeToString(
-            checker.getTypeOfSymbolAtLocation(
-                signature,
-                signature.valueDeclaration
-            ),
-            namedDeclaration
-        );
+export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): Property {
+    const result: Property = new Property(signature.getName());
+    result.modifier = ComponentFactory.getMemberModifier(namedDeclaration);
+    result.isAbstract = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.AbstractKeyword);
+    result.isOptional = ComponentFactory.isOptional(<ts.PropertyDeclaration>namedDeclaration);
+    result.isStatic = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.StaticKeyword);
+    result.isReadonly = ComponentFactory.isModifier(namedDeclaration, ts.SyntaxKind.ReadonlyKeyword);
+    result.returnType = checker.typeToString(
+        checker.getTypeOfSymbolAtLocation(
+            signature,
+            signature.valueDeclaration
+        ),
+        namedDeclaration
+    );
 
-        return result;
-    }
+    return result;
 }

--- a/src/Factories/TypeParameterFactory.ts
+++ b/src/Factories/TypeParameterFactory.ts
@@ -1,29 +1,27 @@
 import ts from 'typescript';
 import { TypeParameter } from '../Components/TypeParameter';
-import { ComponentFactory } from './ComponentFactory';
+import * as ComponentFactory from './ComponentFactory';
 
-export namespace TypeParameterFactory {
-    export function getConstraint(memberDeclaration: ts.Declaration, checker: ts.TypeChecker): ts.Type | undefined {
-        const effectiveConstraint: ts.TypeNode | undefined =
-            ts.getEffectiveConstraintOfTypeParameter(<ts.TypeParameterDeclaration>memberDeclaration);
+export function getConstraint(memberDeclaration: ts.Declaration, checker: ts.TypeChecker): ts.Type | undefined {
+    const effectiveConstraint: ts.TypeNode | undefined =
+        ts.getEffectiveConstraintOfTypeParameter(<ts.TypeParameterDeclaration>memberDeclaration);
 
-        if (effectiveConstraint === undefined) {
-            return;
-        }
-
-        return checker.getTypeFromTypeNode(effectiveConstraint);
+    if (effectiveConstraint === undefined) {
+        return;
     }
 
-    export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): TypeParameter {
-        const result: TypeParameter = new TypeParameter(signature.getName());
+    return checker.getTypeFromTypeNode(effectiveConstraint);
+}
 
-        const constraintType: ts.Type | undefined = getConstraint(namedDeclaration, checker);
+export function create(signature: ts.Symbol, namedDeclaration: ts.NamedDeclaration, checker: ts.TypeChecker): TypeParameter {
+    const result: TypeParameter = new TypeParameter(signature.getName());
 
-        if (constraintType !== undefined) {
-            result.constraint = checker.typeToString(constraintType);
-            result.constraintFile = ComponentFactory.getOriginalFileOriginalType(constraintType, checker);
-        }
+    const constraintType: ts.Type | undefined = getConstraint(namedDeclaration, checker);
 
-        return result;
+    if (constraintType !== undefined) {
+        result.constraint = checker.typeToString(constraintType);
+        result.constraintFile = ComponentFactory.getOriginalFileOriginalType(constraintType, checker);
     }
+
+    return result;
 }

--- a/src/Models/Formatter.ts
+++ b/src/Models/Formatter.ts
@@ -38,10 +38,7 @@ export abstract class Formatter {
         return [];
     }
 
-    // @ts-ignore
-    public addAssociation(type1: string, cardinality: string, type2: string) : string[] {
-        return [];
-    }
+    public abstract addAssociation(type1: string, cardinality: string, type2: string) : string[];
 
     public serializeFile(file: File) : string {
         const result: string[] = [];
@@ -163,7 +160,7 @@ export abstract class Formatter {
                         }
                         const key: string = `${part.name} ${cardinality} ${typeName}`;
                         if (typeName !== part.name &&
-                            !outputConstraints.hasOwnProperty(key) && mappedTypes.hasOwnProperty(typeName)) {
+                            !Object.prototype.hasOwnProperty.call(outputConstraints, key) && Object.prototype.hasOwnProperty.call(mappedTypes, typeName)) {
                             associations.push(...this.addAssociation(part.name, cardinality, typeName));
                             outputConstraints[key] = true;
                         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 
-// tslint:disable:no-console
-
 import commander from 'commander';
 import fs from 'fs';
 import G from 'glob';
 import os from 'os';
 import path from 'path';
 import ts from 'typescript';
-import { tplant } from './tplant';
+import * as tplant from './tplant';
 import { encode } from 'plantuml-encoder';
-const plantuml = require('node-plantuml');
+import pjson = require("../package.json");
 
 const AVAILABLE_PLANTUML_EXTENSIONS: string[] = ['svg', 'png', 'txt'];
 
+/* eslint-disable @typescript-eslint/no-var-requires */
+const plantuml = require("node-plantuml");
+
 commander
-    .version(require('../package').version) // tslint:disable-line
+    .version(pjson.version)
     .option('-i, --input <path>', 'Define the path of the Typescript file')
     .option('-o, --output <path>', 'Define the path of the output file. If not defined, it\'ll output on the STDOUT')
     .option(
@@ -69,20 +70,17 @@ G(<string>commander.input, {}, (err: Error | null, matches: string[]): void => {
         return;
     }
 
-    // tslint:disable-next-line non-literal-fs-path
     fs.writeFileSync(<string>commander.output, plantUMLDocument, 'utf-8');
 });
 
 function findTsConfigFile(inputPath: string, tsConfigPath?: string): string | undefined {
     if (tsConfigPath !== undefined) {
-        // tslint:disable-next-line non-literal-fs-path
         const tsConfigStats: fs.Stats = fs.statSync(tsConfigPath);
         if (tsConfigStats.isFile()) {
             return tsConfigPath;
         }
         if (tsConfigStats.isDirectory()) {
             const tsConfigFilePath: string = path.resolve(tsConfigPath, 'tsconfig.json');
-            // tslint:disable-next-line non-literal-fs-path
             if (fs.existsSync(tsConfigFilePath)) {
                 return tsConfigFilePath;
             }
@@ -90,13 +88,11 @@ function findTsConfigFile(inputPath: string, tsConfigPath?: string): string | un
     }
 
     const localTsConfigFile: string = path.resolve(path.dirname(inputPath), 'tsconfig.json');
-    // tslint:disable-next-line non-literal-fs-path
     if (fs.existsSync(localTsConfigFile)) {
         return localTsConfigFile;
     }
 
     const cwdTsConfigFile: string = path.resolve(process.cwd(), 'tsconfig.json');
-    // tslint:disable-next-line non-literal-fs-path
     if (fs.existsSync(cwdTsConfigFile)) {
         return cwdTsConfigFile;
     }
@@ -110,7 +106,6 @@ function getCompilerOptions(tsConfigFilePath?: string): ts.CompilerOptions {
     }
 
     const reader: (path: string) => string | undefined =
-        // tslint:disable-next-line non-literal-fs-path
         (filePath: string): string | undefined => fs.readFileSync(filePath, 'utf8');
     const configFile: { config?: { compilerOptions: ts.CompilerOptions }; error?: ts.Diagnostic } =
         ts.readConfigFile(tsConfigFilePath, reader);

--- a/src/tplant.ts
+++ b/src/tplant.ts
@@ -6,129 +6,126 @@ import { Formatter } from './Models/Formatter';
 import { IComponentComposite } from './Models/IComponentComposite';
 
 import { Class } from './Components/Class';
-import { FileFactory } from './Factories/FileFactory';
+import * as FileFactory from './Factories/FileFactory';
 import { MermaidFormat } from './Formatter/MermaidFormat';
 import { ICommandOptions } from './Models/ICommandOptions';
 
-export namespace tplant {
+export function generateDocumentation(
+    fileNames: ReadonlyArray<string>,
+    options: ts.CompilerOptions = ts.getDefaultCompilerOptions()
+): IComponentComposite[] {
 
-    export function generateDocumentation(
-        fileNames: ReadonlyArray<string>,
-        options: ts.CompilerOptions = ts.getDefaultCompilerOptions()
-    ): IComponentComposite[] {
+    // Build a program using the set of root file names in fileNames
+    const program: ts.Program = ts.createProgram(fileNames, options);
 
-        // Build a program using the set of root file names in fileNames
-        const program: ts.Program = ts.createProgram(fileNames, options);
+    // Get the checker, we will use it to find more about classes
+    const checker: ts.TypeChecker = program.getTypeChecker();
 
-        // Get the checker, we will use it to find more about classes
-        const checker: ts.TypeChecker = program.getTypeChecker();
+    const result: IComponentComposite[] = [];
 
-        const result: IComponentComposite[] = [];
-
-        // Visit every sourceFile in the program
-        program.getSourceFiles()
-            .forEach((sourceFile: ts.SourceFile): void => {
-                if (!sourceFile.isDeclarationFile) {
-                    const file: IComponentComposite | undefined = FileFactory.create(sourceFile.fileName, sourceFile, checker);
-                    if (file !== undefined) {
-                        result.push(file);
-                    }
+    // Visit every sourceFile in the program
+    program.getSourceFiles()
+        .forEach((sourceFile: ts.SourceFile): void => {
+            if (!sourceFile.isDeclarationFile) {
+                const file: IComponentComposite | undefined = FileFactory.create(sourceFile.fileName, sourceFile, checker);
+                if (file !== undefined) {
+                    result.push(file);
                 }
-            });
-
-        return result;
-    }
-
-    export function convertToPlant(files: IComponentComposite[], options: ICommandOptions = {
-        associations: false,
-        onlyInterfaces: false,
-        format: 'plantuml',
-        onlyClasses: false
-    }): string {
-
-        let formatter : Formatter;
-        if (options.format === 'mermaid') {
-            formatter = new MermaidFormat(options);
-        } else {
-            formatter = new PlantUMLFormat(options);
-        }
-
-        // Only display interfaces
-        if (options.onlyClasses) {
-            for (const file of files) {
-                (<File>file).parts = (<File>file).parts
-                    .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.CLASS);
-            }
-        } else if (options.onlyInterfaces) {
-            for (const file of files) {
-                (<File>file).parts = (<File>file).parts
-                    .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.INTERFACE);
-            }
-        } else if (options.targetClass !== undefined) {
-            // Find the class to display
-            const target : Class = <Class> findClass(files, options.targetClass);
-            const parts : IComponentComposite[] = [];
-            if (target !== undefined) {
-                parts.push(target);
-                // Add all the ancestor for the class recursively
-                let parent : string | undefined = target.extendsClass;
-                // Add the parent
-                while (parent !== undefined) {
-                    const parentClass : Class = <Class> findClass(files, parent);
-                    parts.push(parentClass);
-                    parts.push(...getInterfaces(files, parentClass));
-                    parent = parentClass.extendsClass;
-                }
-                // Add all the interface
-                parts.push(...getInterfaces(files, target));
-                // Add all child class recursively
-                parts.push(...findChildClass(files, target));
-            }
-
-            return formatter.renderFiles(parts, false);
-        }
-
-        return formatter.renderFiles(files, options.associations);
-    }
-
-    function getInterfaces(files:  IComponentComposite[], comp: Class) : IComponentComposite[] {
-        const res: IComponentComposite[] = [];
-        comp.implementsInterfaces.forEach((impl: string) => {
-            const implComponent : IComponentComposite | undefined = findClass(files, impl);
-            if (implComponent !== undefined) {
-                res.push(implComponent);
             }
         });
 
-        return res;
+    return result;
+}
+
+export function convertToPlant(files: IComponentComposite[], options: ICommandOptions = {
+    associations: false,
+    onlyInterfaces: false,
+    format: 'plantuml',
+    onlyClasses: false
+}): string {
+
+    let formatter : Formatter;
+    if (options.format === 'mermaid') {
+        formatter = new MermaidFormat(options);
+    } else {
+        formatter = new PlantUMLFormat(options);
     }
 
-    function findClass(files: IComponentComposite[], name: string) : IComponentComposite | undefined {
+    // Only display interfaces
+    if (options.onlyClasses) {
         for (const file of files) {
-            for (const part of (<File>file).parts) {
-                if (part.name === name) {
-                    return part;
-                }
+            (<File>file).parts = (<File>file).parts
+                .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.CLASS);
+        }
+    } else if (options.onlyInterfaces) {
+        for (const file of files) {
+            (<File>file).parts = (<File>file).parts
+                .filter((part: IComponentComposite): boolean => part.componentKind === ComponentKind.INTERFACE);
+        }
+    } else if (options.targetClass !== undefined) {
+        // Find the class to display
+        const target : Class = <Class> findClass(files, options.targetClass);
+        const parts : IComponentComposite[] = [];
+        if (target !== undefined) {
+            parts.push(target);
+            // Add all the ancestor for the class recursively
+            let parent : string | undefined = target.extendsClass;
+            // Add the parent
+            while (parent !== undefined) {
+                const parentClass : Class = <Class> findClass(files, parent);
+                parts.push(parentClass);
+                parts.push(...getInterfaces(files, parentClass));
+                parent = parentClass.extendsClass;
+            }
+            // Add all the interface
+            parts.push(...getInterfaces(files, target));
+            // Add all child class recursively
+            parts.push(...findChildClass(files, target));
+        }
+
+        return formatter.renderFiles(parts, false);
+    }
+
+    return formatter.renderFiles(files, options.associations);
+}
+
+function getInterfaces(files:  IComponentComposite[], comp: Class) : IComponentComposite[] {
+    const res: IComponentComposite[] = [];
+    comp.implementsInterfaces.forEach((impl: string) => {
+        const implComponent : IComponentComposite | undefined = findClass(files, impl);
+        if (implComponent !== undefined) {
+            res.push(implComponent);
+        }
+    });
+
+    return res;
+}
+
+function findClass(files: IComponentComposite[], name: string) : IComponentComposite | undefined {
+    for (const file of files) {
+        for (const part of (<File>file).parts) {
+            if (part.name === name) {
+                return part;
             }
         }
-
-        return undefined;
     }
 
-    function findChildClass(files: IComponentComposite[], comp: IComponentComposite) : IComponentComposite[] {
-        const res: IComponentComposite[] = [];
-        for (const file of files) {
-            (<File>file).parts
-                .forEach((part: IComponentComposite): void => {
-                    if (part instanceof Class && (part).extendsClass === comp.name) {
-                        res.push(part);
-                        // Reset interface
-                        part.implementsInterfaces = [];
-                        res.push(...findChildClass(files, part));
-                    }
-                });
-        }
+    return undefined;
+}
 
-        return res;
+function findChildClass(files: IComponentComposite[], comp: IComponentComposite) : IComponentComposite[] {
+    const res: IComponentComposite[] = [];
+    for (const file of files) {
+        (<File>file).parts
+            .forEach((part: IComponentComposite): void => {
+                if (part instanceof Class && (part).extendsClass === comp.name) {
+                    res.push(part);
+                    // Reset interface
+                    part.implementsInterfaces = [];
+                    res.push(...findChildClass(files, part));
+                }
+            });
     }
+
+    return res;
 }

--- a/test/arguments.test.ts
+++ b/test/arguments.test.ts
@@ -1,5 +1,5 @@
 import * as os from 'os';
-import { tplant } from '../src/tplant';
+import * as tplant from '../src/tplant';
 
 describe('Test commander options', () => {
 

--- a/test/cjk.test.ts
+++ b/test/cjk.test.ts
@@ -1,5 +1,5 @@
 
-import { tplant } from '../src/tplant';
+import * as tplant from '../src/tplant';
 
 describe('Parse codes that contains CJK characters', () => {
     it('generate PlantUML for classes that contains CJK characters', () => {

--- a/test/handbook.test.ts
+++ b/test/handbook.test.ts
@@ -1,5 +1,5 @@
 import * as os from 'os';
-import { tplant } from '../src/tplant';
+import * as tplant from '../src/tplant';
 
 describe('Parse Handbook codes', () => {
 

--- a/test/mermaid/handbook.test.ts
+++ b/test/mermaid/handbook.test.ts
@@ -1,4 +1,4 @@
-import { tplant } from '../../src/tplant';
+import * as tplant from '../../src/tplant';
 import { join } from "path";
 import { readFileSync } from "fs";
 

--- a/test/mermaid/playground.test.ts
+++ b/test/mermaid/playground.test.ts
@@ -1,4 +1,4 @@
-import { tplant } from '../../src/tplant';
+import * as tplant from '../../src/tplant';
 import { join } from "path";
 import { readFileSync } from "fs";
 

--- a/test/playground.test.ts
+++ b/test/playground.test.ts
@@ -1,5 +1,5 @@
 import * as os from 'os';
-import { tplant } from '../src/tplant';
+import * as tplant from '../src/tplant';
 
 describe('Parse Playground codes', () => {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "strictPropertyInitialization": true,    /* Enable strict checking of property initialization in classes. */
     "noImplicitThis": true,                  /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": true,                    /* Parse in strict mode and emit "use strict" for each source file. */
+    "resolveJsonModule": true,
     /* Additional Checks */
     "noUnusedLocals": true,                  /* Report errors on unused locals. */
     "noUnusedParameters": true,              /* Report errors on unused parameters. */

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,0 @@
-{
-    "extends": [
-        "tslint:recommended",
-        "tslint-microsoft-contrib"
-    ],
-    "rules": {
-        "no-relative-imports": false
-    }
-}


### PR DESCRIPTION
Updates to use eslint versus tslint. Attempting to bring this project up to date with recent technologies. tslint has been [deprecated since 2019](https://blog.palantir.com/tslint-in-2019-1a144c2317a9).