### PR TITLE
fix: remove filenames in typescript symbols

### DIFF
--- a/src/Factories/ComponentFactory.ts
+++ b/src/Factories/ComponentFactory.ts
@@ -102,8 +102,9 @@ export function getHeritageClauseNames(heritageClause: ts.HeritageClause, checke
         const symbolAtLocation: ts.Symbol | undefined = checker.getSymbolAtLocation(nodeObject.expression);
         if (symbolAtLocation !== undefined) {
             const ogFile: string = getOriginalFile(symbolAtLocation, checker);
-
-            return [checker.getFullyQualifiedName(symbolAtLocation), ogFile];
+            let qualifiedName = checker.getFullyQualifiedName(symbolAtLocation);
+            qualifiedName = qualifiedName.replace(/"[^"]+"\./, "");
+            return [qualifiedName, ogFile];
         }
 
         return ['', ''];

--- a/test/playground.test.ts
+++ b/test/playground.test.ts
@@ -112,6 +112,27 @@ describe('Parse Playground codes', () => {
                     '@enduml'].join(os.EOL));
     });
 
+    it('generate PlantUML in same file', () => {
+        expect(tplant.convertToPlant(tplant.generateDocumentation(`
+            export interface Foo {
+                bar: number;
+                foo: string;
+            }
+            export interface Bar extends Foo {
+                foobar: boolean;
+            }
+        `))).toEqual(
+            ['@startuml',
+                'interface Foo {',
+                '    +bar: number',
+                '    +foo: string',
+                '}',
+                'interface Bar extends Foo {',
+                '    +foobar: boolean',
+                '}',
+            '@enduml'].join(os.EOL));
+    });
+
     it('generate PlantUML for Generics/RecursiveGenericType.ts', () => {
         expect(tplant.convertToPlant(tplant.generateDocumentation(['test/Playground/Generics/RecursiveGenericType.ts'])))
             .toEqual(


### PR DESCRIPTION
This can close #115 . I added the included sample from the issue in a regression test. Should always be able to remove the filename that typescript sometimes includes from the output.